### PR TITLE
Fix Zip File Upload and use Static Subdomain for Dev Environement

### DIFF
--- a/etc/AppResDevDocker.properties
+++ b/etc/AppResDevDocker.properties
@@ -18,7 +18,7 @@ isMac=true
 #isGoogleMapsV3=true
 
 site.protocol=https
-site.imgDomainApp=www.antweb.org
+site.imgDomainApp=static.antweb.org
 #site.imgDomainApp=localhost/antweb
 site.domain=localhost
 

--- a/src/org/calacademy/antweb/upload/SpecimenUploader.java
+++ b/src/org/calacademy/antweb/upload/SpecimenUploader.java
@@ -78,7 +78,7 @@ public class SpecimenUploader extends Uploader {
             A.log("copyAndUnzipFile() exists:" + exists + " zippedName:" + zippedName + " tempDirName:" + tempDirName + " outName:" + outName + " fullOutputPath:" + fullOutputPath);
             if (exists) {
                 try {
-                    String command = "unzip -d -o " + tempDirName + " " + fullOutputPath;  // zippedName;
+                    String command = "unzip -o -d " + tempDirName + " " + fullOutputPath;  // zippedName;
                     A.log("copyAndUnzip() command:" + command);
                     Process process = Runtime.getRuntime().exec(command);
 


### PR DESCRIPTION
The Unzip method in Specimen Uploader uses wrong zip command,

```
zip -d -o ...
```

This is incorrect because the -d option requires a directory argument immediately after it.

The correct syntax should be,

```
zip -o -d ...
```