### PR TITLE
fix: add validation for specimen list and ZIP upload (#25)

### DIFF
--- a/src/org/calacademy/antweb/upload/UploadAction.java
+++ b/src/org/calacademy/antweb/upload/UploadAction.java
@@ -1001,6 +1001,9 @@ public class UploadAction extends Action {
 		LogMgr.emptyFile(fullPath);
 		LogMgr.appendFile(fullPath, Specimen.getTabDelimHeader());
 
+		StringBuilder validationErrors = new StringBuilder();
+		int errorCount = 0;
+
 		while (line != null) {
             //A.log("getSpecimenList() lineNum:" + lineNum + " line:" + line);
 
@@ -1017,26 +1020,53 @@ public class UploadAction extends Action {
 
 			++lineNum;
 			if (line == null) continue;
-			boolean parseLine = true;
-            String specimenCode = line;
-            if (specimenCode == null || specimenCode.contains(" ")) {
-            	messageStr = "<h1>Specimen List</h1><br><br>There seems to be a file format error in file: " + fileName;
-            	s_log.error(messageStr);
-            	return messageStr;
+			String specimenCode = line.trim();
+			if (specimenCode.isEmpty()) {
+				line = in.readLine();
+				continue;
 			}
-			//if (lineNum < 5) A.log("output specimen:" + specimenCode);
 
-			Specimen specimen = specimenDb.getSpecimen(specimenCode);
+			if (specimenCode.contains(" ")) {
+				validationErrors.append("Line " + lineNum + ": specimen code \""
+					+ specimenCode + "\" contains a space character, which is not permitted.<br>");
+				errorCount++;
+				line = in.readLine();
+				continue;
+			}
+
+			try {
+				if (!specimenDb.exists(specimenCode)) {
+					validationErrors.append("Line " + lineNum + ": specimen code \""
+						+ specimenCode + "\" was not found in the database.<br>");
+					errorCount++;
+					line = in.readLine();
+					continue;
+				}
+
+				Specimen specimen = specimenDb.getSpecimen(specimenCode);
 			//String taxonName = specimen.getTaxonName();
 			//Taxon taxon = taxonDb.getTaxon(taxonName);
-            String outputLine = specimen.getTabDelimString();
-            LogMgr.appendFile(fullPath, outputLine);
+				String outputLine = specimen.getTabDelimString();
+				LogMgr.appendFile(fullPath, outputLine);
+			} catch (Exception e) {
+				validationErrors.append("Line " + lineNum + ": specimen code \""
+					+ specimenCode + "\" caused an error: " + e.getMessage() + "<br>");
+				errorCount++;
+			}
 
 			line = in.readLine();
 		} // end while loop through lines
 
 		A.log("getSpecimenList() lineNum:" + lineNum + " line:" + line);
-		//http://localhost/antweb//tmp/specimenList.txt
+				//http://localhost/antweb//tmp/specimenList.txt
+
+		if (errorCount > 0) {
+			messageStr = "<h1>Specimen List</h1><br><br>"
+				+ "<b>Upload failed with " + errorCount + " error(s) in file: " + fileName + "</b><br><br>"
+				+ validationErrors.toString();
+			s_log.error("getSpecimenList() " + errorCount + " validation errors in file: " + fileName);
+			return messageStr;
+		}
 
 		messageStr = "<h2>Specimen List</h2><br><br>";
 		messageStr += "<b>'Right-click' and 'Save Link As' to download:</b><br> <a href=\"" + fullUrl + "\">" + outputPath + "</a>";

--- a/web/curate/curate-body.jsp
+++ b/web/curate/curate-body.jsp
@@ -143,16 +143,35 @@ Need Help? Check out the <a href="<%= domainApp %>/documentation.do" target="new
 
 <!-- Universal Specimen Upload -->
         <!-- Antweb, TaxonWorks, or GBIF Specimen (file or Zip File) Upload -->
-
-        <html:form method="POST" action="upload.do" enctype="multipart/form-data">
+        
+        <script type="text/javascript">
+            function validateZipUpload(form) {
+                var fileInput = form.elements['theFile'];
+                if (!fileInput || !fileInput.value) {
+                    alert('Please select a ZIP file to upload.');
+                    return false;
+                }
+                if (!fileInput.value.toLowerCase().endsWith('.zip')) {
+                    alert('Error: Only ZIP files are allowed.');
+                    return false;
+                }
+                return true;
+            }
+        </script>
+        <html:form method="POST" action="upload.do" enctype="multipart/form-data" onsubmit="return validateZipUpload(this);">
 
             <div class="admin_action_item">
             <br>
-                <div class="action_desc"><b>Upload</b> Specimen File or Zip File:<br>&nbsp;&nbsp;&nbsp;</div>
+                <div class="action_desc"><b>Upload</b> Zip File:<br>&nbsp;&nbsp;&nbsp;</div>
                 <div class="action_browse">
-                    <html:file property="theFile" />
+                    <html:file property="theFile" accept=".zip" />
                 </div>
                 <div class="clear"></div>
+                
+                <div style="color: red; font-weight: bold; margin: 10px 0;">
+                    1. Only ZIP Files Allowed<br>
+                    2. If you see Cloudflare timeout just go back to the homepage.
+                </div>
 
             <%
             if (LoginMgr.isAdmin(accessLogin)) { %>
@@ -711,7 +730,7 @@ if (speciesListList != null && !speciesListList.isEmpty()) { %>
     <input type="hidden" name="successkey" value="null" />
     <div class="admin_action_module">
         <div class="admin_action_item">
-            <div class="action_desc"><b>Upload</b> Data File<br>&nbsp;&nbsp;&nbsp;Press submit for documentation</div>
+            <div class="action_desc"><b>Upload</b> Data File<br>&nbsp;&nbsp;&nbsp;For specimen list lookup: upload a .txt file with 'specimen' in the filename (one specimen code per line, no spaces)<br></div>
             <div class="action_browse">
   <html:file property="testFile" />
             </div>


### PR DESCRIPTION
Server: Improve specimen list processing in UploadAction.java by trimming lines, skipping blanks, and collecting validation errors (space-containing codes, missing specimens, and exceptions) into a consolidated error report instead of aborting on the first issue; log error counts and return a user-facing message when validation fails. Client: In curate-body.jsp, add client-side ZIP-only validation (onsubmit JS and accept=".zip"), update form labels and guidance text to clarify ZIP-only uploads and .txt specimen-list instructions, and surface a prominent warning about Cloudflare timeouts.

Closes #25