### PR TITLE
feat: add species list validation tool

### DIFF
--- a/WEB-INF/struts-config.xml
+++ b/WEB-INF/struts-config.xml
@@ -222,6 +222,8 @@
       <form-property name="toSpecies"     type="java.lang.String"/>
       <form-property name="toSubspecies"     type="java.lang.String"/>
   </form-bean>  
+
+  <form-bean name="validateSpeciesListForm" type="org.calacademy.antweb.curate.speciesList.ValidateSpeciesListForm"/>
       
   </form-beans>
 
@@ -608,6 +610,15 @@ We would like to remove getChildImages.  Not needed now in the new UI
             scope="request"
             name="uploadForm">
       <forward name="success" path="/uploadHistory.jsp" />
+    </action>
+
+    <action path="/validateSpeciesList"
+            type="org.calacademy.antweb.curate.speciesList.ValidateSpeciesListAction"
+            scope="request"
+            validate="false"
+            input="/curate/speciesList/validateSpeciesList.jsp"
+            name="validateSpeciesListForm">
+      <forward name="validateSpeciesList" path="/curate/speciesList/validateSpeciesList.jsp" />
     </action>
 
     <action path="/speciesListTool"

--- a/src/org/calacademy/antweb/ValidationParseException.java
+++ b/src/org/calacademy/antweb/ValidationParseException.java
@@ -1,0 +1,7 @@
+package org.calacademy.antweb;
+
+public class ValidationParseException extends Exception {
+    public ValidationParseException(String message) {
+        super(message);
+    }
+}

--- a/src/org/calacademy/antweb/curate/speciesList/SpeciesListValidator.java
+++ b/src/org/calacademy/antweb/curate/speciesList/SpeciesListValidator.java
@@ -1,0 +1,368 @@
+package org.calacademy.antweb.curate.speciesList;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.calacademy.antweb.ValidationParseException;
+
+public class SpeciesListValidator {
+
+    private static final Log s_log = LogFactory.getLog(SpeciesListValidator.class);
+    private final Connection connection;
+
+    public SpeciesListValidator(Connection connection) {
+        this.connection = connection;
+    }
+
+    public ValidateSpeciesReport validate(InputStream inputStream, String charSet, boolean showUnmatched) 
+            throws ValidationParseException, SQLException, IOException {
+
+        ValidateSpeciesReport report = new ValidateSpeciesReport();
+        List<ParsedRow> rows = parseStream(inputStream, charSet);
+        
+        Set<String> matchedTaxonNames = new HashSet<>();
+        
+        for (ParsedRow row : rows) {
+            if (row.hasError) {
+                report.addResult(new ValidateSpeciesResultItem(
+                        row.rowNum, row.rawLine, "", ValidateSpeciesResultItem.Status.FORMAT_ERROR, row.errorMsg, ""));
+                continue;
+            }
+
+            // Normalization
+            String subfamily = normalize(row.subfamily);
+            String genus = normalizeCapitalized(row.genus);
+            String species = normalize(row.species);
+            String subspecies = normalize(row.subspecies);
+
+            if (genus == null || species == null) {
+                report.addResult(new ValidateSpeciesResultItem(
+                    row.rowNum, row.rawLine, "", ValidateSpeciesResultItem.Status.FORMAT_ERROR, "Genus and species are required.", ""));
+                continue;
+            }
+
+            // Human-readable display name: "Genus species [subspecies]"
+            String displayName = genus + " " + species;
+            if (subspecies != null) displayName += " " + subspecies;
+
+            // Resolve the internal DB taxon_name key.
+            // DB taxon_name is entirely lowercase (e.g. "dorylinaeaenictus clavatus atripennis").
+            // When subfamily is known: key = subfamily + genus(lower) + " " + species [+ " " + subspecies]
+            // When subfamily is unknown: query the DB by genus+species columns to get the key.
+            String taxonName = null;
+            String genusLower = genus.toLowerCase();
+            if (subfamily != null) {
+                taxonName = subfamily + genusLower + " " + species;
+                if (subspecies != null) taxonName += " " + subspecies;
+            } else {
+                taxonName = lookupTaxonName(genusLower, species, subspecies);
+            }
+
+            // Lean DB lookup — only status + current_valid_name (avoids expensive image/bioregion queries)
+            TaxonLookupResult result = taxonName != null ? lookupTaxon(taxonName) : null;
+            
+            if (result != null) {
+                if ("valid".equals(result.status)) {
+                    report.addResult(new ValidateSpeciesResultItem(
+                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.EXACT_MATCH, "Exact match.", ""));
+                    matchedTaxonNames.add(taxonName);
+                } else if ("fossil".equals(result.status)) {
+                    report.addResult(new ValidateSpeciesResultItem(
+                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.NOT_FOUND, "Fossil taxon — not an extant valid name.", ""));
+                } else if ("synonym".equals(result.status) || "homonym".equals(result.status)) {
+                    // current_valid_name is an internal DB key (all lowercase, subfamily-prefixed).
+                    // Resolve it to a human-readable display name.
+                    String suggestion = resolveDisplayName(result.currentValidName);
+                    report.addResult(new ValidateSpeciesResultItem(
+                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.AMBIGUOUS, 
+                            "Matched a " + result.status + ".", suggestion != null ? suggestion : ""));
+                } else {
+                    report.addResult(new ValidateSpeciesResultItem(
+                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.AMBIGUOUS, 
+                            "Status is '" + result.status + "'. Expected 'valid'.", ""));
+                }
+            } else {
+                // Fuzzy match using display names for accurate distance calculation
+                String suggestion = getBestFuzzyMatch(displayName, genus);
+                report.addResult(new ValidateSpeciesResultItem(
+                        row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.NOT_FOUND, "Taxon not found.", suggestion));
+            }
+        }
+
+        if (showUnmatched) {
+            populateUnmatched(report, matchedTaxonNames);
+        }
+
+        return report;
+    }
+
+    /**
+     * Minimal status-only DB lookup. Avoids TaxonDb.getTaxon() which fires
+     * expensive image / bioregion queries for every row in production.
+     */
+    private TaxonLookupResult lookupTaxon(String taxonName) throws SQLException {
+        String q = "SELECT status, current_valid_name FROM taxon WHERE taxon_name = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(q)) {
+            stmt.setString(1, taxonName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return new TaxonLookupResult(rs.getString("status"), rs.getString("current_valid_name"));
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * When no subfamily is provided (Format B without subfamily column),
+     * look up the taxon_name by querying genus + species + subspecies columns.
+     */
+    private String lookupTaxonName(String genus, String species, String subspecies) throws SQLException {
+        String subspClause = subspecies != null ? " AND subspecies = ?" : " AND (subspecies IS NULL OR subspecies = '')";
+        String q = "SELECT taxon_name FROM taxon WHERE genus = ? AND species = ?" + subspClause
+                 + " AND status != 'synonym' AND taxarank IN ('species','subspecies') LIMIT 1";
+        try (PreparedStatement stmt = connection.prepareStatement(q)) {
+            stmt.setString(1, genus.toLowerCase());
+            stmt.setString(2, species);
+            if (subspecies != null) stmt.setString(3, subspecies);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) return rs.getString("taxon_name");
+            }
+        } catch (SQLException e) {
+            s_log.warn("lookupTaxonName() genus:" + genus + " e:" + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Resolves an internal DB taxon_name key to a human-readable display name
+     * by querying the DB for its genus/species/subspecies components.
+     * Returns "Genus species [subspecies]" or null if not found.
+     */
+    private String resolveDisplayName(String internalTaxonName) {
+        if (internalTaxonName == null || internalTaxonName.isEmpty()) return null;
+        String q = "SELECT genus, species, subspecies FROM taxon WHERE taxon_name = ? LIMIT 1";
+        try (PreparedStatement stmt = connection.prepareStatement(q)) {
+            stmt.setString(1, internalTaxonName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return buildDisplayName(rs.getString("genus"), rs.getString("species"), rs.getString("subspecies"));
+                }
+            }
+        } catch (SQLException e) {
+            s_log.warn("resolveDisplayName() failed for: " + internalTaxonName + " e:" + e.getMessage());
+        }
+        return internalTaxonName; // fallback: return raw key
+    }
+
+    /**
+     * Builds a human-readable display name from DB components.
+     * Capitalizes genus, returns "Genus species [subspecies]".
+     */
+    private String buildDisplayName(String genus, String species, String subspecies) {
+        if (genus == null || genus.isEmpty()) return null;
+        String g = genus.substring(0, 1).toUpperCase() + genus.substring(1);
+        StringBuilder sb = new StringBuilder(g);
+        if (species != null && !species.isEmpty()) {
+            sb.append(" ").append(species);
+        }
+        if (subspecies != null && !subspecies.isEmpty()) {
+            sb.append(" ").append(subspecies);
+        }
+        return sb.toString();
+    }
+
+    private static class TaxonLookupResult {
+        final String status;
+        final String currentValidName;
+        TaxonLookupResult(String status, String currentValidName) {
+            this.status = status;
+            this.currentValidName = currentValidName;
+        }
+    }
+
+    private String normalize(String s) {
+        if (s == null || s.trim().isEmpty()) return null;
+        return s.trim().toLowerCase();
+    }
+    
+    private String normalizeCapitalized(String s) {
+        if (s == null || s.trim().isEmpty()) return null;
+        s = s.trim().toLowerCase();
+        return s.substring(0, 1).toUpperCase() + s.substring(1);
+    }
+    
+    // Limits fuzzy matching to species sharing the same genus for performance.
+    // Queries genus/species/subspecies columns to build proper display names for comparison.
+    private String getBestFuzzyMatch(String displayName, String genus) {
+        if (genus == null) return "Check spelling.";
+        
+        List<String> candidates = new ArrayList<>();
+        // Query individual columns so we can build proper display names
+        String query = "SELECT genus, species, subspecies FROM taxon WHERE genus = ? AND status = 'valid'";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, genus.toLowerCase());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    String candidate = buildDisplayName(rs.getString("genus"), rs.getString("species"), rs.getString("subspecies"));
+                    if (candidate != null) candidates.add(candidate);
+                }
+            }
+        } catch (SQLException e) {
+            s_log.warn("Fuzzy match query failed: " + e.getMessage());
+            return "Check spelling. (DB error)";
+        }
+        
+        if (candidates.isEmpty()) return "No valid species found for genus " + genus + ".";
+        
+        int bestDistance = Integer.MAX_VALUE;
+        String bestMatch = null;
+        LevenshteinDistance ld = new LevenshteinDistance();
+        
+        for (String candidate : candidates) {
+            int dist = ld.apply(displayName, candidate);
+            if (dist < bestDistance) {
+                bestDistance = dist;
+                bestMatch = candidate;
+            }
+        }
+        
+        if (bestDistance <= 4 && bestMatch != null) {
+            return bestMatch;
+        }
+        
+        return "Check spelling.";
+    }
+    
+    private void populateUnmatched(ValidateSpeciesReport report, Set<String> matchedTaxa) {
+        String q = "select taxon_name from taxon where status = 'valid' and taxarank in ('species', 'subspecies') order by taxon_name";
+        try (PreparedStatement stmt = connection.prepareStatement(q);
+             ResultSet rs = stmt.executeQuery()) {
+            while(rs.next()) {
+                String n = rs.getString(1);
+                if (!matchedTaxa.contains(n)) {
+                    report.addUnmatchedValidTaxon(n);
+                }
+            }
+        } catch (SQLException e) {
+            s_log.warn("Failed retrieving unmatched: " + e.getMessage());
+        }
+    }
+
+    private List<ParsedRow> parseStream(InputStream is, String charset) throws ValidationParseException, IOException {
+        List<ParsedRow> results = new ArrayList<>();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is, charset));
+        
+        String headerLine = reader.readLine();
+        if (headerLine == null) throw new ValidationParseException("File is empty.");
+        
+        // Handle BOM
+        if (headerLine.startsWith("\uFEFF")) {
+            headerLine = headerLine.substring(1);
+        }
+        
+        String[] headers = headerLine.toLowerCase().replace("\r", "").split("\t");
+        boolean isOptionA = false;
+        boolean isOptionB = false;
+        
+        int subfamIdx = -1, genusIdx = -1, speciesIdx = -1, subspIdx = -1, taxonNameIdx = -1;
+        
+        for (int i=0; i<headers.length; i++) {
+            String h = headers[i].trim();
+            if ("subfamily".equals(h)) subfamIdx = i;
+            else if ("genus".equals(h)) genusIdx = i;
+            else if ("species".equals(h)) speciesIdx = i;
+            else if ("subspecies".equals(h)) subspIdx = i;
+            else if ("taxon_name".equals(h)) taxonNameIdx = i;
+        }
+        
+        if (genusIdx != -1 && speciesIdx != -1) isOptionA = true;
+        else if (taxonNameIdx != -1) isOptionB = true;
+        
+        if (!isOptionA && !isOptionB) {
+            throw new ValidationParseException("Unrecognized headers. File must contain either: ['genus', 'species'] or ['taxon_name'].");
+        }
+        
+        int rowNum = 1;
+        String line;
+        while ((line = reader.readLine()) != null) {
+            rowNum++;
+            line = line.replace("\r", "");
+            if (line.trim().isEmpty()) continue; // skip blank lines
+            
+            if (rowNum > 50000) {
+                throw new ValidationParseException("Maximum row limit of 50,000 exceeded. Stopping parse.");
+            }
+            
+            ParsedRow pr = new ParsedRow();
+            pr.rowNum = rowNum;
+            pr.rawLine = line;
+            
+            String[] tokens = line.split("\t", -1);
+            pr.subfamily = safeGet(tokens, subfamIdx);
+            
+            if (isOptionA) {
+                pr.genus = safeGet(tokens, genusIdx);
+                pr.species = safeGet(tokens, speciesIdx);
+                pr.subspecies = safeGet(tokens, subspIdx);
+                
+                if (pr.genus == null || pr.species == null) {
+                    pr.hasError = true;
+                    pr.errorMsg = "Missing genus or species token.";
+                }
+            } else {
+                String taxNameRaw = safeGet(tokens, taxonNameIdx);
+                if (taxNameRaw == null || taxNameRaw.trim().isEmpty()) {
+                    pr.hasError = true; pr.errorMsg = "Empty taxon_name.";
+                } else {
+                    String[] nameParts = taxNameRaw.trim().split("\\s+");
+                    if (nameParts.length < 2 || nameParts.length > 3) {
+                        pr.hasError = true;
+                        pr.errorMsg = "taxon_name value '" + taxNameRaw + "' has " + nameParts.length + " tokens. Expected 'Genus species' or 'Genus species subspecies'.";
+                    } else {
+                        pr.genus = nameParts[0];
+                        pr.species = nameParts[1];
+                        if (nameParts.length == 3) {
+                            pr.subspecies = nameParts[2];
+                        }
+                    }
+                }
+            }
+            
+            results.add(pr);
+        }
+        
+        return results;
+    }
+    
+    private String safeGet(String[] t, int idx) {
+        if (idx == -1 || idx >= t.length) return null;
+        String val = t[idx].trim();
+        return val.isEmpty() ? null : val;
+    }
+
+    private static class ParsedRow {
+        int rowNum;
+        String rawLine;
+        String subfamily;
+        String genus;
+        String species;
+        String subspecies;
+        boolean hasError = false;
+        String errorMsg;
+    }
+}

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesListAction.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesListAction.java
@@ -1,0 +1,113 @@
+package org.calacademy.antweb.curate.speciesList;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.upload.FormFile;
+import org.calacademy.antweb.util.DBUtil;
+import org.calacademy.antweb.util.Check;
+import org.calacademy.antweb.ValidationParseException;
+
+public class ValidateSpeciesListAction extends SpeciesListSuperAction {
+
+    private static final Log s_log = LogFactory.getLog(ValidateSpeciesListAction.class);
+
+    @Override
+    public ActionForward execute(ActionMapping mapping, ActionForm form,
+            HttpServletRequest request, HttpServletResponse response) {
+
+        ActionForward loginCheck = Check.login(request, mapping);
+        if (loginCheck != null) return loginCheck;
+
+        ValidateSpeciesListForm toolForm = (ValidateSpeciesListForm) form;
+        FormFile uploadedFile = toolForm.getFile();
+
+        Connection connection = null;
+        try {
+            // Check downloads first, since they won't have the uploaded file!
+            if ("download".equals(toolForm.getAction()) || "downloadCorrected".equals(toolForm.getAction())) {
+                ValidateSpeciesReport cachedReport = (ValidateSpeciesReport) request.getSession().getAttribute("validationReport");
+                if (cachedReport != null) {
+                    response.setContentType("text/tab-separated-values");
+                    if ("downloadCorrected".equals(toolForm.getAction())) {
+                        response.setHeader("Content-Disposition", "attachment; filename=\"corrected_species_list_for_upload.tsv\"");
+                        response.getWriter().write(cachedReport.generateCorrectedTsvReport());
+                    } else {
+                        response.setHeader("Content-Disposition", "attachment; filename=\"validation_report.tsv\"");
+                        response.getWriter().write(cachedReport.generateTsvReport());
+                    }
+                    return null;
+                } else {
+                    request.setAttribute("message", "Session expired or no report found. Please re-validate your file.");
+                    return mapping.findForward("validateSpeciesList");
+                }
+            }
+
+            // Initial render or empty submission
+            if (uploadedFile == null || uploadedFile.getFileSize() == 0) {
+                return mapping.findForward("validateSpeciesList");
+            }
+
+            String filename = uploadedFile.getFileName().toLowerCase();
+            if (!filename.endsWith(".txt") && !filename.endsWith(".tsv")) {
+                request.setAttribute("message", "File must be a tab-delimited .txt or .tsv file.");
+                return mapping.findForward("validateSpeciesList");
+            }
+            
+            // 5MB max
+            if (uploadedFile.getFileSize() > (5 * 1024 * 1024)) {
+                request.setAttribute("message", "File is too large. Maximum size is 5MB (approx 50,000 rows).");
+                return mapping.findForward("validateSpeciesList");
+            }
+
+            InputStream fileStream = uploadedFile.getInputStream();
+
+            DataSource ds = getDataSource(request, "longConPool");
+            connection = DBUtil.getConnection(ds, "ValidateSpeciesListAction.execute()");
+            if (connection == null) {
+                request.setAttribute("message", "Could not obtain database connection.");
+                return mapping.findForward("validateSpeciesList");
+            }
+
+            // Enforce strictly read-only mode to prevent ALL data modifications.
+            connection.setReadOnly(true);
+
+            SpeciesListValidator validator = new SpeciesListValidator(connection);
+            ValidateSpeciesReport report = validator.validate(fileStream, "UTF-8", toolForm.isShowUnmatched());
+
+            request.getSession().setAttribute("validationReport", report);
+            request.setAttribute("validationReport", report);
+            return mapping.findForward("validateSpeciesList");
+
+        } catch (ValidationParseException e) {
+            s_log.warn("ValidateSpeciesListAction parse error: " + e.getMessage());
+            request.setAttribute("message", e.getMessage());
+            return mapping.findForward("validateSpeciesList");
+        } catch (SQLException e) {
+            s_log.error("ValidateSpeciesListAction DB error: " + e);
+            request.setAttribute("message", "Database error occurred during validation: " + e.getMessage());
+            return mapping.findForward("validateSpeciesList");
+        } catch (IOException e) {
+            s_log.error("ValidateSpeciesListAction IO error: " + e);
+            request.setAttribute("message", "Error reading uploaded file: " + e.getMessage());
+            return mapping.findForward("validateSpeciesList");
+        } finally {
+            if (connection != null) {
+                try { 
+                    connection.setReadOnly(false); // Reset to default pool state
+                } catch (SQLException e) { s_log.error("Failed to reset connection readOnly status", e); }
+            }
+            DBUtil.close(connection, this, "ValidateSpeciesListAction.execute()");
+        }
+    }
+}

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesListForm.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesListForm.java
@@ -1,0 +1,43 @@
+package org.calacademy.antweb.curate.speciesList;
+
+import javax.servlet.http.HttpServletRequest;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.upload.FormFile;
+
+public class ValidateSpeciesListForm extends ActionForm {
+    private FormFile file;
+    private String action;
+    private boolean showUnmatched;
+
+    public FormFile getFile() {
+        return file;
+    }
+
+    public void setFile(FormFile file) {
+        this.file = file;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public boolean isShowUnmatched() {
+        return showUnmatched;
+    }
+
+    public void setShowUnmatched(boolean showUnmatched) {
+        this.showUnmatched = showUnmatched;
+    }
+
+    @Override
+    public void reset(ActionMapping mapping, HttpServletRequest request) {
+        this.file = null;
+        this.action = null;
+        this.showUnmatched = false;
+    }
+}

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReport.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReport.java
@@ -1,0 +1,110 @@
+package org.calacademy.antweb.curate.speciesList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValidateSpeciesReport {
+    private final List<ValidateSpeciesResultItem> exactMatches = new ArrayList<>();
+    private final List<ValidateSpeciesResultItem> problems = new ArrayList<>();
+    private final List<ValidateSpeciesResultItem> formatErrors = new ArrayList<>();
+    
+    // For "Show Unmatched" feature
+    private final List<String> unmatchedValidTaxa = new ArrayList<>();
+
+    private int totalInputRows = 0;
+    
+    // Limits
+    private boolean rowLimitExceeded = false;
+
+    public void addResult(ValidateSpeciesResultItem item) {
+        totalInputRows++;
+        if (item.getStatus() == ValidateSpeciesResultItem.Status.EXACT_MATCH) {
+            exactMatches.add(item);
+        } else if (item.getStatus() == ValidateSpeciesResultItem.Status.FORMAT_ERROR) {
+            formatErrors.add(item);
+        } else {
+            problems.add(item);
+        }
+    }
+
+    public void addUnmatchedValidTaxon(String taxonName) {
+        this.unmatchedValidTaxa.add(taxonName);
+    }
+
+    public List<ValidateSpeciesResultItem> getExactMatches() { return exactMatches; }
+    public List<ValidateSpeciesResultItem> getProblems() { return problems; }
+    public List<ValidateSpeciesResultItem> getFormatErrors() { return formatErrors; }
+    public List<String> getUnmatchedValidTaxa() { return unmatchedValidTaxa; }
+    
+    public int getTotalInputRows() { return totalInputRows; }
+    public int getExactMatchCount() { return exactMatches.size(); }
+    public int getProblemCount() { return problems.size(); }
+    public int getFormatErrorCount() { return formatErrors.size(); }
+    public int getUnmatchedCount() { return unmatchedValidTaxa.size(); }
+
+    public void setRowLimitExceeded(boolean exceeded) { this.rowLimitExceeded = exceeded; }
+    public boolean isRowLimitExceeded() { return rowLimitExceeded; }
+
+    public String generateTsvReport() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Row\tInput Raw\tNormalized Taxon Name\tStatus\tMessage\tSuggestion\n");
+        
+        List<ValidateSpeciesResultItem> all = new ArrayList<>();
+        all.addAll(formatErrors);
+        all.addAll(problems);
+        all.addAll(exactMatches);
+        
+        // Sort by row number
+        all.sort((a, b) -> Integer.compare(a.getRowNum(), b.getRowNum()));
+        
+        for (ValidateSpeciesResultItem item : all) {
+            // Sanitize rawLine: replace embedded tabs to avoid corrupting TSV columns
+            String safeRaw = item.getInputRaw().replace("\t", "  ");
+            sb.append(item.getRowNum()).append("\t")
+              .append(safeRaw).append("\t")
+              .append(item.getNormalizedName()).append("\t")
+              .append(item.getStatus().name()).append("\t")
+              .append(item.getMessage()).append("\t")
+              .append(item.getSuggestion()).append("\n");
+        }
+
+        if (!unmatchedValidTaxa.isEmpty()) {
+            sb.append("\n\n--- UNMATCHED VALID ANTWEB TAXA ---\n");
+            sb.append("Taxon Name\n");
+            for (String t : unmatchedValidTaxa) {
+                sb.append(t).append("\n");
+            }
+        }
+
+        return sb.toString();
+    }
+    
+    public String generateCorrectedTsvReport() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("taxon_name\n");
+        
+        List<ValidateSpeciesResultItem> all = new ArrayList<>();
+        all.addAll(formatErrors);
+        all.addAll(problems);
+        all.addAll(exactMatches);
+        
+        // Sort by row number
+        all.sort((a, b) -> Integer.compare(a.getRowNum(), b.getRowNum()));
+        
+        for (ValidateSpeciesResultItem item : all) {
+            String taxonStr = "";
+            if (item.getStatus() == ValidateSpeciesResultItem.Status.EXACT_MATCH) {
+                taxonStr = item.getNormalizedName();
+            } else if (item.getSuggestion() != null && !item.getSuggestion().isEmpty()
+                       && Character.isUpperCase(item.getSuggestion().charAt(0))) {
+                // Only include suggestions that look like actual taxon names (start with uppercase genus).
+                // Excludes messages like "Check spelling.", "No valid species found...", etc.
+                taxonStr = item.getSuggestion();
+            }
+            if (!taxonStr.isEmpty()) {
+                sb.append(taxonStr).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesResultItem.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesResultItem.java
@@ -1,0 +1,28 @@
+package org.calacademy.antweb.curate.speciesList;
+
+public final class ValidateSpeciesResultItem {
+    public enum Status { EXACT_MATCH, NOT_FOUND, FORMAT_ERROR, AMBIGUOUS }
+
+    private final int rowNum;
+    private final String inputRaw;
+    private final String normalizedName;
+    private final Status status;
+    private final String message;
+    private final String suggestion;
+
+    public ValidateSpeciesResultItem(int rowNum, String inputRaw, String normalizedName, Status status, String message, String suggestion) {
+        this.rowNum = rowNum;
+        this.inputRaw = inputRaw != null ? inputRaw : "";
+        this.normalizedName = normalizedName != null ? normalizedName : "";
+        this.status = status;
+        this.message = message != null ? message : "";
+        this.suggestion = suggestion != null ? suggestion : "";
+    }
+
+    public int getRowNum() { return rowNum; }
+    public String getInputRaw() { return inputRaw; }
+    public String getNormalizedName() { return normalizedName; }
+    public Status getStatus() { return status; }
+    public String getMessage() { return message; }
+    public String getSuggestion() { return suggestion; }
+}

--- a/web/curate/curate-body.jsp
+++ b/web/curate/curate-body.jsp
@@ -489,6 +489,23 @@ Upload Curator File
 <!-- Projects -->                
 <!-- Download Species List -->   
 
+<% if (accessLogin.isCurator()) { %>
+    <div class="admin_action_module">
+        <div class="admin_action_item">
+            <div style="float:left;">
+                <h2>Read-Only Tools</h2>
+            </div>
+            <div class="clear"></div>
+        </div>
+        <div class="admin_action_item">
+          <div class="action_desc">
+            &nbsp;&nbsp;&nbsp;<a href="<%= AntwebProps.getDomainApp() %>/validateSpeciesList.do">Validate Species List (Pre-flight checker)</a>
+          </div>  
+          <div class="clear"></div>
+        </div>
+    </div>
+<% } %>
+
 <% if (accessLogin.isDeveloper()) { %>  <!-- was isAdmin() -->
 
         <div class="admin_action_item">

--- a/web/curate/speciesList/validateSpeciesList-body.jsp
+++ b/web/curate/speciesList/validateSpeciesList-body.jsp
@@ -1,0 +1,178 @@
+<%@ page language="java" %>
+<%@ page errorPage = "/error.jsp" %>
+<%@ page import="java.util.*" %>
+<%@ page import="org.calacademy.antweb.*" %>
+<%@ page import="org.calacademy.antweb.util.*" %>
+<%@ page import="org.calacademy.antweb.curate.speciesList.*" %>
+
+<%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
+
+<jsp:useBean id="validateSpeciesListForm" scope="request" class="org.calacademy.antweb.curate.speciesList.ValidateSpeciesListForm" />
+<jsp:setProperty name="validateSpeciesListForm" property="*" />
+
+<%
+    String domainApp = AntwebProps.getDomainApp();
+    String message = (String) request.getAttribute("message");
+    ValidateSpeciesReport report = (ValidateSpeciesReport) request.getAttribute("validationReport");
+%>
+
+<div class="admin_left">
+
+    <h1>Validate Species List</h1>
+    <div style="color: #666; font-style: italic; margin-bottom: 20px;">
+        Read-Only Validator. Safe to use for reconciliation workflows. No database modifications will occur.
+    </div>
+
+    <% if (message != null && !message.isEmpty()) { %>
+        <div style="border: 1px solid red; padding: 10px; color: red; background-color: #fee; margin-bottom: 20px; font-weight: bold;">
+            <%= message %>
+        </div>
+    <% } %>
+
+    <div class="admin_action_module">
+        <div class="admin_action_item">
+            <h2>Validation Instructions</h2>
+            <p>Upload a tab-delimited <b>.txt</b> or <b>.tsv</b> file. Maximum file size: <b>5MB (approx. 50,000 rows)</b>. The first row must contain column headers.</p>
+            
+            <p><b>Two formats are supported:</b></p>
+            
+            <div style="margin-left: 20px;">
+                <b>Format 1 (Separate Columns):</b> Required headers: <code>genus</code>, <code>species</code>. Optional: <code>subfamily</code>, <code>subspecies</code>.<br>
+                <div style="background-color: #f5f5f5; padding: 10px; margin: 5px 0 15px 0; font-family: monospace;">
+                    subfamily&#9;genus&#9;species&#9;subspecies<br>
+                    Myrmicinae&#9;Acromyrmex&#9;balzani&#9;multituber<br>
+                    Dorylinae&#9;Aenictus&#9;clavatus&#9;atripennis
+                </div>
+
+                <b>Format 2 (Combined Taxon):</b> Required header: <code>taxon_name</code> (case-insensitive).<br>
+                <div style="background-color: #f5f5f5; padding: 10px; margin: 5px 0; font-family: monospace;">
+                    subfamily&#9;taxon_name<br>
+                    Myrmicinae&#9;Acromyrmex balzani multituber<br>
+                    Dorylinae&#9;Aenictus clavatus atripennis
+                </div>
+            </div>
+
+            <br>
+            <p><a href="<%= domainApp %>/data/validateSpeciesList_template.txt" download>Download Template File</a></p>
+        </div>
+    </div>
+
+    <div class="admin_action_module">
+        <div class="admin_action_item">
+            <h2>Upload File for Validation</h2>
+            
+            <html:form method="POST" action="validateSpeciesList.do" enctype="multipart/form-data">
+                <input type="hidden" name="action" value="" />
+                
+                <div class="action_browse" style="margin-bottom: 15px;">
+                    <html:file property="file" accept=".txt,.tsv"/>
+                </div>
+                
+                <div style="margin-bottom: 15px;">
+                    <html:checkbox property="showUnmatched" value="true" />
+                    <label for="showUnmatched">Also report valid AntWeb taxa not present in my list</label>
+                </div>
+                
+                <div class="align_left">
+                    <input type="submit" value="Validate Species List" style="padding: 5px 15px;" />
+                </div>
+                <div class="clear"></div>
+            </html:form>
+        </div>
+    </div>
+
+
+    <% if (report != null) { %>
+        <div style="margin-top: 30px;">
+            <h2>Validation Report Summary</h2>
+            <table border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse; margin-bottom: 15px;">
+                <tr><th align="left">Total Rows Processed</th><td><%= report.getTotalInputRows() %></td></tr>
+                <tr><th align="left">Exact Matches</th><td style="color: green; font-weight: bold;"><%= report.getExactMatchCount() %></td></tr>
+                <tr><th align="left">Not Found / Ambiguous</th><td style="color: orange; font-weight: bold;"><%= report.getProblemCount() %></td></tr>
+                <tr><th align="left">Format Errors</th><td style="color: red; font-weight: bold;"><%= report.getFormatErrorCount() %></td></tr>
+                <% if (validateSpeciesListForm.isShowUnmatched()) { %>
+                    <tr><th align="left">Unmatched AntWeb Taxa</th><td style="font-weight: bold;"><%= report.getUnmatchedCount() %></td></tr>
+                <% } %>
+            </table>
+
+            <div style="display: flex; gap: 10px; margin-bottom: 20px;">
+                <html:form method="POST" action="validateSpeciesList.do">
+                    <input type="hidden" name="action" value="download" />
+                    <input type="hidden" name="showUnmatched" value="<%= validateSpeciesListForm.isShowUnmatched() %>" />
+                    <input type="submit" value="Download Diagnostic TSV Report" style="padding: 5px 15px;" />
+                </html:form>
+                <html:form method="POST" action="validateSpeciesList.do">
+                    <input type="hidden" name="action" value="downloadCorrected" />
+                    <input type="hidden" name="showUnmatched" value="<%= validateSpeciesListForm.isShowUnmatched() %>" />
+                    <input type="submit" value="Download Corrected Curated Dataset" style="padding: 5px 15px; font-weight: bold; color: green;" />
+                </html:form>
+            </div>
+
+            <% if (report.getProblemCount() > 0 || report.getFormatErrorCount() > 0) { %>
+                <h3>Problems & Format Errors Log</h3>
+                <table border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse; width: 100%;">
+                    <tr style="background-color: #eee;">
+                        <th>Row</th>
+                        <th>Input Raw</th>
+                        <th>Normalized Taxon Name</th>
+                        <th>Status</th>
+                        <th>Message</th>
+                        <th>Suggestion</th>
+                    </tr>
+                    
+                    <% 
+                    List<ValidateSpeciesResultItem> issues = new ArrayList<>();
+                    issues.addAll(report.getFormatErrors());
+                    issues.addAll(report.getProblems());
+                    issues.sort((a, b) -> Integer.compare(a.getRowNum(), b.getRowNum()));
+                    
+                    for (ValidateSpeciesResultItem item : issues) { 
+                        String bg = item.getStatus() == ValidateSpeciesResultItem.Status.FORMAT_ERROR ? "#ffe6e6" : "#fff3cd";
+                    %>
+                        <tr style="background-color: <%= bg %>;">
+                            <td><%= item.getRowNum() %></td>
+                            <td><%= item.getInputRaw() != null ? item.getInputRaw().replace("<", "&lt;").replace(">", "&gt;") : "" %></td>
+                            <td><%= item.getNormalizedName() != null ? item.getNormalizedName() : "" %></td>
+                            <td style="font-weight: bold;"><%= item.getStatus().name() %></td>
+                            <td><%= item.getMessage() %></td>
+                            <% if (item.getSuggestion() != null && !item.getSuggestion().isEmpty()) { %>
+                                <td style="font-weight: bold; color: #000;"><%= item.getSuggestion() %>
+                                    <% if (item.getStatus() == ValidateSpeciesResultItem.Status.NOT_FOUND) { %>
+                                        <div style="font-size: 0.8em; color: green; margin-top: 4px;">↑ Try replacing with this valid name.</div>
+                                    <% } %>
+                                </td>
+                            <% } else { %>
+                                <td></td>
+                            <% } %>
+                        </tr>
+                    <% } %>
+                </table>
+            <% } %>
+
+            <% if (report.getFormatErrorCount() == 0 && report.getProblemCount() == 0) { %>
+                <div style="color: green; font-weight: bold; margin-top: 10px;">
+                    ✓ All rows matched valid extant taxa exactly.
+                </div>
+            <% } %>
+            
+            <% if (validateSpeciesListForm.isShowUnmatched() && !report.getUnmatchedValidTaxa().isEmpty()) { %>
+                 <h3 style="margin-top: 30px;">Unmatched Valid AntWeb Taxa (Preview)</h3>
+                 <div style="max-height: 200px; overflow-y: scroll; border: 1px solid #ccc; padding: 10px; background-color: #f9f9f9; font-family: monospace;">
+                 <% 
+                    int maxPreview = Math.min(100, report.getUnmatchedValidTaxa().size());
+                    for (int i=0; i<maxPreview; i++) {
+                         out.println(report.getUnmatchedValidTaxa().get(i) + "<br>");
+                    }
+                    if (report.getUnmatchedValidTaxa().size() > 100) {
+                         out.println("<br><i>... and " + (report.getUnmatchedValidTaxa().size() - 100) + " more (Download TSV for full list)</i>");
+                    }
+                 %>
+                 </div>
+            <% } %>
+            
+        </div>
+    <% } %>
+
+</div>

--- a/web/curate/speciesList/validateSpeciesList.jsp
+++ b/web/curate/speciesList/validateSpeciesList.jsp
@@ -1,0 +1,14 @@
+<%@ page language="java" %>
+<%@ page errorPage = "error.jsp" %>
+<%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
+<%@ taglib uri="/WEB-INF/struts-tiles.tld" prefix="tiles" %>
+
+<%@include file="/curate/curatorCheck.jsp" %>
+<%@include file="/common/antweb_admin-defs.jsp" %>
+
+<tiles:insert beanName="antweb.default" beanScope="request" flush="true">
+	<tiles:put name="title" value="Validate Species List" />
+	<tiles:put name="body-content" value="/curate/speciesList/validateSpeciesList-body.jsp" />	
+</tiles:insert>

--- a/web/data/validateSpeciesList_template.txt
+++ b/web/data/validateSpeciesList_template.txt
@@ -1,0 +1,4 @@
+subfamily	genus	species	subspecies
+Myrmicinae	Acromyrmex	balzani	multituber
+Dorylinae	Aenictus	clavatus	atripennis
+Myrmicinae	Atta	cephalotes	lutea


### PR DESCRIPTION
Introduce a read-only pre-flight validator for uploaded species lists. Adds backend validator + DTOs (SpeciesListValidator, ValidateSpeciesReport, ValidateSpeciesResultItem, ValidationParseException), Struts form/action (ValidateSpeciesListForm, ValidateSpeciesListAction) and route, and JSP UI (validateSpeciesList.jsp + body) with a downloadable template. Validator supports two input formats (genus+species columns or taxon_name), enforces a 5MB / ~50k-row limit, performs minimal DB lookups (status/current_valid_name), fuzzy matching by genus, and an option to list unmatched valid taxa. Also adds link to the Curate tools in curate-body.jsp.