### PR TITLE
Enhance deploy script; add staging workflow

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
-# Having sensitive error checking making the script fail.
-#set -euxo pipefail
+set -euo pipefail
+
+compose() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  else
+    docker-compose "$@"
+  fi
+}
+
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-master}"
 
 # Let's assume antweb is in home directory of the ssh user
-cd $HOME/antweb
+cd "$HOME/antweb"
 
 # Get the latest source code
-git checkout master
-git pull origin master --no-edit
+git fetch origin "$DEPLOY_BRANCH"
+git checkout "$DEPLOY_BRANCH"
+git pull --rebase origin "$DEPLOY_BRANCH"
 
 # Restart docker compose services
-docker-compose exec antweb ant deploy
-docker-compose restart antweb
+# -T disables pseudo-TTY allocation (required when running non-interactively via SSH/CI)
+compose exec -T antweb ant deploy
+compose restart antweb

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,25 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.STAGING_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.STAGING_SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to Staging Server
+        run: ssh ${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }} 'DEPLOY_BRANCH=staging bash -s' < .github/scripts/deploy.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,10 +20,8 @@ jobs:
 
       - name: Test API Build
         run: |
-          cd docker/api
-          docker build -t antweb/api:dev .
+          docker build -t antweb/api:dev -f docker/api/Dockerfile .
 
       - name: Test Antweb Build
         run: |
-          cd docker/api
-          docker build -t antweb/antweb:dev .
+          docker build -t antweb/antweb:dev -f docker/antweb/Dockerfile .


### PR DESCRIPTION
Make deploy.sh more robust: enable set -euo pipefail, add a compose() wrapper to support both `docker compose` and `docker-compose`, quote HOME path, and use DEPLOY_BRANCH (default master) with fetch/checkout/pull --rebase. Use non-interactive compose exec (-T) when running ant deploy. Add a new GitHub Actions workflow (deploy-staging) to deploy on pushes to staging via SSH, passing DEPLOY_BRANCH=staging. Also update tests workflow to build images by specifying Dockerfile paths instead of changing directories.