### PR TITLE
[docker/caddy/Caddyfile] use Cloudflare SSL in production instead of Let's encrypt

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -13,14 +13,17 @@
 }
 
 antweb.org {
+    tls /data/cf-origin.crt /data/cf-origin.key
     redir https://www.antweb.org{uri}
 }
 
 api.antweb.org {
+    tls /data/cf-origin.crt /data/cf-origin.key
     redir https://www.antweb.org{uri} permanent
 }
 
 www.antweb.org {
+    tls /data/cf-origin.crt /data/cf-origin.key
     @bots {
         header_regexp User-Agent "(?i)(CCBot|GPTBot|Googlebot-Images|Sogou|SenutoBot|SiteScoreBot|Twitterbot|YisouSpider|IABot|Turnitin|CFNetwork/.* Darwin|ClaudeBot|SemrushBot|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Sogou|Exabot|facebot|facebookexternalhit|Bytespider|AppleBot|Swiftbot|Slurp Bot|GoogleOther|Google-InspectionTool|MJ12bot|Alexa crawler|Soso Spider|Pinterestbot|Dotbot|AhrefsBot|archive.org_bot|scrapy|PetalBot|Amazonbot|DataForSeoBot|Yeti|Googlebot-Image|meta-externalagent)"
     }


### PR DESCRIPTION
This is a cherry picked commit from production so we can keep the remote repo clean.