### PR TITLE
Add fossil flag and categorize validation results

### DIFF
--- a/WEB-INF/struts-configDbAnt.xml
+++ b/WEB-INF/struts-configDbAnt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
-<!-- 
+<!--
 On dev and live server there is a softlink created pointing to the DB config file.
 
 root@antweb:~/antweb# ls -al WEB-INF/struts-configDb*
@@ -20,7 +20,7 @@ Another connection is defined in DBSimpleUtil.getDataSource()
 
 <struts-config>
   <data-sources>
-  
+
     <data-source key="conPool" type="com.mchange.v2.c3p0.ComboPooledDataSource">    <!-- add  destroy-method="close" ? -->
       <set-property property="factory" value="org.apache.naming.factory.BeanFactory"/>
       <set-property property="auth" value="Container"/>
@@ -38,8 +38,8 @@ Another connection is defined in DBSimpleUtil.getDataSource()
       <set-property property="unreturnedConnectionTimeout" value="200"/>  <!-- was 600 == 10 min -->
       <set-property property="debugUnreturnedConnectionStackTraces" value="false"/>
 
-      <set-property property="testConnectionOnCheckin" value="true"/> 
-      <set-property property="idleConnectionTestPeriod" value="60"/> 
+      <set-property property="testConnectionOnCheckin" value="true"/>
+      <set-property property="idleConnectionTestPeriod" value="60"/>
       <set-property property="maxIdleTimeExcessConnections" value="60"/>
     </data-source>
 
@@ -60,8 +60,8 @@ Another connection is defined in DBSimpleUtil.getDataSource()
       <set-property property="unreturnedConnectionTimeout" value="600"/>
       <set-property property="debugUnreturnedConnectionStackTraces" value="false"/>
 
-      <set-property property="testConnectionOnCheckin" value="true"/> 
-      <set-property property="idleConnectionTestPeriod" value="300"/> 
+      <set-property property="testConnectionOnCheckin" value="true"/>
+      <set-property property="idleConnectionTestPeriod" value="300"/>
       <set-property property="maxIdleTimeExcessConnections" value="240"/>
     </data-source>
 
@@ -76,19 +76,19 @@ Another connection is defined in DBSimpleUtil.getDataSource()
       <set-property property="jdbcUrl" value="jdbc:mysql://mysql:3306/ant?autoReconnect=true&amp;useUnicode=true&amp;characterEncoding=UTF-8&amp;characterSetResults=utf8&amp;connectionCollation=utf8_general_ci&amp;useSSL=false&amp;serverTimezone=UTC"/>
       <set-property property="name" value="jdbc/antDb"/> <!-- not used elsewhere -->
       <set-property property="testConnectionOnCheckout" value="true"/>
-      <set-property property="autoCommitOnClose" value="true"/> 
+      <set-property property="autoCommitOnClose" value="true"/>
 
       <!-- See DBUtil.java for documentation -->
       <set-property property="unreturnedConnectionTimeout" value="3600"/> <!-- 4200 / 60 is 70 min -->  <!-- 10800 / 60 is 3 hours -->
       <set-property property="debugUnreturnedConnectionStackTraces" value="false"/>
-       
-      <set-property property="testConnectionOnCheckin" value="true"/> 
+
+      <set-property property="testConnectionOnCheckin" value="true"/>
       <set-property property="idleConnectionTestPeriod" value="300"/>
       <set-property property="maxIdleTimeExcessConnections" value="240"/>
-              
+
     </data-source>
 
-<!--  
+<!--
 Does not work:
       <set-property property="zeroDateTimeBehavior" value="convertToNull"/>
       <set-property property="jdbcUrl" value="jdbc:mysql://mysql:3306/ant?autoReconnect=true&amp;characterEncoding=utf-8"/>

--- a/src/org/calacademy/antweb/curate/speciesList/SpeciesListValidator.java
+++ b/src/org/calacademy/antweb/curate/speciesList/SpeciesListValidator.java
@@ -38,7 +38,8 @@ public class SpeciesListValidator {
         for (ParsedRow row : rows) {
             if (row.hasError) {
                 report.addResult(new ValidateSpeciesResultItem(
-                        row.rowNum, row.rawLine, "", ValidateSpeciesResultItem.Status.FORMAT_ERROR, row.errorMsg, ""));
+                        row.rowNum, row.rawLine, "", ValidateSpeciesResultItem.Status.FORMAT_ERROR,
+                        "", false, row.errorMsg, "", false));
                 continue;
             }
 
@@ -50,7 +51,8 @@ public class SpeciesListValidator {
 
             if (genus == null || species == null) {
                 report.addResult(new ValidateSpeciesResultItem(
-                    row.rowNum, row.rawLine, "", ValidateSpeciesResultItem.Status.FORMAT_ERROR, "Genus and species are required.", ""));
+                    row.rowNum, row.rawLine, "", ValidateSpeciesResultItem.Status.FORMAT_ERROR,
+                    "", false, "Genus and species are required.", "", false));
                 continue;
             }
 
@@ -71,34 +73,33 @@ public class SpeciesListValidator {
                 taxonName = lookupTaxonName(genusLower, species, subspecies);
             }
 
-            // Lean DB lookup — only status + current_valid_name (avoids expensive image/bioregion queries)
+            // Lean DB lookup - only validation fields, avoiding expensive image/bioregion queries.
             TaxonLookupResult result = taxonName != null ? lookupTaxon(taxonName) : null;
             
             if (result != null) {
                 if ("valid".equals(result.status)) {
                     report.addResult(new ValidateSpeciesResultItem(
-                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.EXACT_MATCH, "Exact match.", ""));
+                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.EXACT_MATCH,
+                            result.status, false, "Exact match.", "", result.fossil));
                     matchedTaxonNames.add(taxonName);
-                } else if ("fossil".equals(result.status)) {
-                    report.addResult(new ValidateSpeciesResultItem(
-                            row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.NOT_FOUND, "Fossil taxon — not an extant valid name.", ""));
-                } else if ("synonym".equals(result.status) || "homonym".equals(result.status)) {
+                } else if ("synonym".equals(result.status)) {
                     // current_valid_name is an internal DB key (all lowercase, subfamily-prefixed).
                     // Resolve it to a human-readable display name.
                     String suggestion = resolveDisplayName(result.currentValidName);
                     report.addResult(new ValidateSpeciesResultItem(
                             row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.AMBIGUOUS, 
-                            "Matched a " + result.status + ".", suggestion != null ? suggestion : ""));
+                            result.status, suggestion != null, "Matched a synonym.", suggestion != null ? suggestion : "", result.fossil));
                 } else {
                     report.addResult(new ValidateSpeciesResultItem(
                             row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.AMBIGUOUS, 
-                            "Status is '" + result.status + "'. Expected 'valid'.", ""));
+                            result.status, false, "Status is '" + result.status + "'. Expected 'valid'.", "", result.fossil));
                 }
             } else {
                 // Fuzzy match using display names for accurate distance calculation
-                String suggestion = getBestFuzzyMatch(displayName, genus);
+                FuzzyMatch suggestion = getBestFuzzyMatch(displayName, genus);
                 report.addResult(new ValidateSpeciesResultItem(
-                        row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.NOT_FOUND, "Taxon not found.", suggestion));
+                        row.rowNum, row.rawLine, displayName, ValidateSpeciesResultItem.Status.NOT_FOUND,
+                        "", suggestion.hasValidTaxon(), "Taxon not found.", suggestion.displayText, suggestion.fossil));
             }
         }
 
@@ -114,12 +115,15 @@ public class SpeciesListValidator {
      * expensive image / bioregion queries for every row in production.
      */
     private TaxonLookupResult lookupTaxon(String taxonName) throws SQLException {
-        String q = "SELECT status, current_valid_name FROM taxon WHERE taxon_name = ?";
+        String q = "SELECT status, current_valid_name, fossil FROM taxon WHERE taxon_name = ?";
         try (PreparedStatement stmt = connection.prepareStatement(q)) {
             stmt.setString(1, taxonName);
             try (ResultSet rs = stmt.executeQuery()) {
                 if (rs.next()) {
-                    return new TaxonLookupResult(rs.getString("status"), rs.getString("current_valid_name"));
+                    return new TaxonLookupResult(
+                            rs.getString("status"),
+                            rs.getString("current_valid_name"),
+                            rs.getInt("fossil") == 1);
                 }
             }
         }
@@ -133,7 +137,8 @@ public class SpeciesListValidator {
     private String lookupTaxonName(String genus, String species, String subspecies) throws SQLException {
         String subspClause = subspecies != null ? " AND subspecies = ?" : " AND (subspecies IS NULL OR subspecies = '')";
         String q = "SELECT taxon_name FROM taxon WHERE genus = ? AND species = ?" + subspClause
-                 + " AND status != 'synonym' AND taxarank IN ('species','subspecies') LIMIT 1";
+                 + " AND taxarank IN ('species','subspecies')"
+                 + " ORDER BY CASE WHEN status = 'valid' THEN 0 ELSE 1 END LIMIT 1";
         try (PreparedStatement stmt = connection.prepareStatement(q)) {
             stmt.setString(1, genus.toLowerCase());
             stmt.setString(2, species);
@@ -188,9 +193,25 @@ public class SpeciesListValidator {
     private static class TaxonLookupResult {
         final String status;
         final String currentValidName;
-        TaxonLookupResult(String status, String currentValidName) {
+        final boolean fossil;
+        TaxonLookupResult(String status, String currentValidName, boolean fossil) {
             this.status = status;
             this.currentValidName = currentValidName;
+            this.fossil = fossil;
+        }
+    }
+
+    private static class FuzzyMatch {
+        final String displayText;
+        final boolean hasValidTaxon;
+        final boolean fossil;
+        FuzzyMatch(String displayText, boolean hasValidTaxon, boolean fossil) {
+            this.displayText = displayText;
+            this.hasValidTaxon = hasValidTaxon;
+            this.fossil = fossil;
+        }
+        boolean hasValidTaxon() {
+            return hasValidTaxon;
         }
     }
 
@@ -207,34 +228,34 @@ public class SpeciesListValidator {
     
     // Limits fuzzy matching to species sharing the same genus for performance.
     // Queries genus/species/subspecies columns to build proper display names for comparison.
-    private String getBestFuzzyMatch(String displayName, String genus) {
-        if (genus == null) return "Check spelling.";
+    private FuzzyMatch getBestFuzzyMatch(String displayName, String genus) {
+        if (genus == null) return new FuzzyMatch("Check spelling.", false, false);
         
-        List<String> candidates = new ArrayList<>();
+        List<FuzzyMatch> candidates = new ArrayList<>();
         // Query individual columns so we can build proper display names
-        String query = "SELECT genus, species, subspecies FROM taxon WHERE genus = ? AND status = 'valid'";
+        String query = "SELECT genus, species, subspecies, fossil FROM taxon WHERE genus = ? AND status = 'valid'";
         
         try (PreparedStatement stmt = connection.prepareStatement(query)) {
             stmt.setString(1, genus.toLowerCase());
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     String candidate = buildDisplayName(rs.getString("genus"), rs.getString("species"), rs.getString("subspecies"));
-                    if (candidate != null) candidates.add(candidate);
+                    if (candidate != null) candidates.add(new FuzzyMatch(candidate, true, rs.getInt("fossil") == 1));
                 }
             }
         } catch (SQLException e) {
             s_log.warn("Fuzzy match query failed: " + e.getMessage());
-            return "Check spelling. (DB error)";
+            return new FuzzyMatch("Check spelling. (DB error)", false, false);
         }
         
-        if (candidates.isEmpty()) return "No valid species found for genus " + genus + ".";
+        if (candidates.isEmpty()) return new FuzzyMatch("No valid species found for genus " + genus + ".", false, false);
         
         int bestDistance = Integer.MAX_VALUE;
-        String bestMatch = null;
+        FuzzyMatch bestMatch = null;
         LevenshteinDistance ld = new LevenshteinDistance();
         
-        for (String candidate : candidates) {
-            int dist = ld.apply(displayName, candidate);
+        for (FuzzyMatch candidate : candidates) {
+            int dist = ld.apply(displayName, candidate.displayText);
             if (dist < bestDistance) {
                 bestDistance = dist;
                 bestMatch = candidate;
@@ -245,7 +266,7 @@ public class SpeciesListValidator {
             return bestMatch;
         }
         
-        return "Check spelling.";
+        return new FuzzyMatch("Check spelling.", false, false);
     }
     
     private void populateUnmatched(ValidateSpeciesReport report, Set<String> matchedTaxa) {

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReport.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReport.java
@@ -41,13 +41,35 @@ public class ValidateSpeciesReport {
     public int getProblemCount() { return problems.size(); }
     public int getFormatErrorCount() { return formatErrors.size(); }
     public int getUnmatchedCount() { return unmatchedValidTaxa.size(); }
+    public int getNeedAttentionCount() {
+        int count = 0;
+        for (ValidateSpeciesResultItem item : problems) {
+            String category = item.getCategory();
+            if (ValidateSpeciesResultItem.CATEGORY_SPELLING.equals(category)
+                    || ValidateSpeciesResultItem.CATEGORY_JUNIOR_SYNONYM.equals(category)
+                    || ValidateSpeciesResultItem.CATEGORY_COMBINATION_CHANGED.equals(category)
+                    || ValidateSpeciesResultItem.CATEGORY_NOT_FOUND.equals(category)) {
+                count++;
+            }
+        }
+        return count;
+    }
+    public int getInformationalCount() {
+        int count = 0;
+        for (ValidateSpeciesResultItem item : problems) {
+            if (ValidateSpeciesResultItem.CATEGORY_KNOWN_NOT_VALID.equals(item.getCategory())) {
+                count++;
+            }
+        }
+        return count;
+    }
 
     public void setRowLimitExceeded(boolean exceeded) { this.rowLimitExceeded = exceeded; }
     public boolean isRowLimitExceeded() { return rowLimitExceeded; }
 
     public String generateTsvReport() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Row\tInput Raw\tNormalized Taxon Name\tStatus\tMessage\tSuggestion\n");
+        sb.append("Row\tInput Raw\tNormalized Taxon Name\tStatus\tCategory\tFossil\tMessage\tSuggestion\n");
         
         List<ValidateSpeciesResultItem> all = new ArrayList<>();
         all.addAll(formatErrors);
@@ -64,6 +86,8 @@ public class ValidateSpeciesReport {
               .append(safeRaw).append("\t")
               .append(item.getNormalizedName()).append("\t")
               .append(item.getStatus().name()).append("\t")
+              .append(item.getCategory()).append("\t")
+              .append(item.getFossilDisplay()).append("\t")
               .append(item.getMessage()).append("\t")
               .append(item.getSuggestion()).append("\n");
         }

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesResultItem.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesResultItem.java
@@ -3,18 +3,39 @@ package org.calacademy.antweb.curate.speciesList;
 public final class ValidateSpeciesResultItem {
     public enum Status { EXACT_MATCH, NOT_FOUND, FORMAT_ERROR, AMBIGUOUS }
 
+    public static final String CATEGORY_EXACT_MATCH = "Exact match";
+    public static final String CATEGORY_SPELLING = "Spelling";
+    public static final String CATEGORY_JUNIOR_SYNONYM = "Junior synonym";
+    public static final String CATEGORY_COMBINATION_CHANGED = "Combination changed";
+    public static final String CATEGORY_KNOWN_NOT_VALID = "Known but not valid";
+    public static final String CATEGORY_NOT_FOUND = "Not found";
+    public static final String CATEGORY_FORMAT_ERROR = "Format error";
+
     private final int rowNum;
     private final String inputRaw;
     private final String normalizedName;
     private final Status status;
+    private final String lookupStatus;
+    private final boolean hasSuggestedValidName;
+    private final String category;
+    private final boolean fossil;
     private final String message;
     private final String suggestion;
 
     public ValidateSpeciesResultItem(int rowNum, String inputRaw, String normalizedName, Status status, String message, String suggestion) {
+        this(rowNum, inputRaw, normalizedName, status, "", false, message, suggestion, false);
+    }
+
+    public ValidateSpeciesResultItem(int rowNum, String inputRaw, String normalizedName, Status status,
+            String lookupStatus, boolean hasSuggestedValidName, String message, String suggestion, boolean fossil) {
         this.rowNum = rowNum;
         this.inputRaw = inputRaw != null ? inputRaw : "";
         this.normalizedName = normalizedName != null ? normalizedName : "";
         this.status = status;
+        this.lookupStatus = lookupStatus != null ? lookupStatus : "";
+        this.hasSuggestedValidName = hasSuggestedValidName;
+        this.category = computeCategory(status, this.lookupStatus, hasSuggestedValidName);
+        this.fossil = fossil;
         this.message = message != null ? message : "";
         this.suggestion = suggestion != null ? suggestion : "";
     }
@@ -23,6 +44,39 @@ public final class ValidateSpeciesResultItem {
     public String getInputRaw() { return inputRaw; }
     public String getNormalizedName() { return normalizedName; }
     public Status getStatus() { return status; }
+    public String getLookupStatus() { return lookupStatus; }
+    public boolean hasSuggestedValidName() { return hasSuggestedValidName; }
+    public String getCategory() { return category; }
+    public boolean isFossil() { return fossil; }
+    public String getFossilDisplay() { return fossil ? "yes" : "no"; }
     public String getMessage() { return message; }
     public String getSuggestion() { return suggestion; }
+
+    private static String computeCategory(Status status, String lookupStatus, boolean hasSuggestedValidName) {
+        if (status == Status.FORMAT_ERROR) {
+            return CATEGORY_FORMAT_ERROR;
+        }
+        if ("valid".equals(lookupStatus) || status == Status.EXACT_MATCH) {
+            return CATEGORY_EXACT_MATCH;
+        }
+        if ("unavailable misspelling".equals(lookupStatus)) {
+            return CATEGORY_SPELLING;
+        }
+        if (status == Status.NOT_FOUND) {
+            return hasSuggestedValidName ? CATEGORY_SPELLING : CATEGORY_NOT_FOUND;
+        }
+        if ("synonym".equals(lookupStatus)) {
+            return CATEGORY_JUNIOR_SYNONYM;
+        }
+        if ("obsolete combination".equals(lookupStatus)) {
+            return CATEGORY_COMBINATION_CHANGED;
+        }
+        if ("unidentifiable".equals(lookupStatus)
+                || "unavailable".equals(lookupStatus)
+                || "unrecognized".equals(lookupStatus)
+                || "homonym".equals(lookupStatus)) {
+            return CATEGORY_KNOWN_NOT_VALID;
+        }
+        return CATEGORY_KNOWN_NOT_VALID;
+    }
 }

--- a/test/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReportTest.java
+++ b/test/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReportTest.java
@@ -1,0 +1,83 @@
+package test.org.calacademy.antweb.curate.speciesList;
+
+import junit.framework.TestCase;
+import org.calacademy.antweb.curate.speciesList.ValidateSpeciesReport;
+import org.calacademy.antweb.curate.speciesList.ValidateSpeciesResultItem;
+
+public class ValidateSpeciesReportTest extends TestCase {
+
+    public void testCategoryMappingUsesStructuredFields() {
+        assertCategory("Exact match", exact("valid"));
+        assertCategory("Spelling", problem("unavailable misspelling", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Spelling", notFound(true));
+        assertCategory("Not found", notFound(false));
+        assertCategory("Junior synonym", problem("synonym", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Combination changed", problem("obsolete combination", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Known but not valid", problem("unidentifiable", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Known but not valid", problem("unavailable", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Known but not valid", problem("unrecognized", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Known but not valid", problem("homonym", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        assertCategory("Format error", formatError());
+    }
+
+    public void testHeadlineCountsSeparateActionableInformationalAndFormatErrors() {
+        ValidateSpeciesReport report = new ValidateSpeciesReport();
+
+        for (int i = 0; i < 23; i++) report.addResult(problem("unavailable misspelling", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        for (int i = 0; i < 24; i++) report.addResult(problem("synonym", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        for (int i = 0; i < 24; i++) report.addResult(problem("obsolete combination", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        for (int i = 0; i < 31; i++) report.addResult(notFound(false));
+        for (int i = 0; i < 183; i++) report.addResult(problem("unrecognized", ValidateSpeciesResultItem.Status.AMBIGUOUS, false));
+        report.addResult(formatError());
+        report.addResult(exact("valid"));
+
+        assertEquals(102, report.getNeedAttentionCount());
+        assertEquals(183, report.getInformationalCount());
+        assertEquals(1, report.getFormatErrorCount());
+        assertEquals(1, report.getExactMatchCount());
+    }
+
+    public void testTsvIncludesCategoryAndFossilColumns() {
+        ValidateSpeciesReport report = new ValidateSpeciesReport();
+        report.addResult(new ValidateSpeciesResultItem(
+                2, "Acromyrmex\tbalzani", "Acromyrmex balzani",
+                ValidateSpeciesResultItem.Status.AMBIGUOUS,
+                "synonym", false, "Matched a synonym.", "Acromyrmex validus", true));
+
+        String tsv = report.generateTsvReport();
+
+        assertTrue(tsv.startsWith("Row\tInput Raw\tNormalized Taxon Name\tStatus\tCategory\tFossil\tMessage\tSuggestion\n"));
+        assertTrue(tsv.contains("2\tAcromyrmex  balzani\tAcromyrmex balzani\tAMBIGUOUS\tJunior synonym\tyes\tMatched a synonym.\tAcromyrmex validus\n"));
+    }
+
+    private static void assertCategory(String expected, ValidateSpeciesResultItem item) {
+        assertEquals(expected, item.getCategory());
+    }
+
+    private static ValidateSpeciesResultItem exact(String lookupStatus) {
+        return new ValidateSpeciesResultItem(
+                1, "input", "Input validus",
+                ValidateSpeciesResultItem.Status.EXACT_MATCH,
+                lookupStatus, false, "Exact match.", "", false);
+    }
+
+    private static ValidateSpeciesResultItem problem(String lookupStatus, ValidateSpeciesResultItem.Status status, boolean fossil) {
+        return new ValidateSpeciesResultItem(
+                1, "input", "Input invalidus",
+                status, lookupStatus, false, "Problem.", "", fossil);
+    }
+
+    private static ValidateSpeciesResultItem notFound(boolean hasSuggestedValidName) {
+        return new ValidateSpeciesResultItem(
+                1, "input", "Input missingus",
+                ValidateSpeciesResultItem.Status.NOT_FOUND,
+                "", hasSuggestedValidName, "Taxon not found.", hasSuggestedValidName ? "Input validus" : "Check spelling.", false);
+    }
+
+    private static ValidateSpeciesResultItem formatError() {
+        return new ValidateSpeciesResultItem(
+                1, "input", "",
+                ValidateSpeciesResultItem.Status.FORMAT_ERROR,
+                "", false, "Missing genus or species token.", "", false);
+    }
+}

--- a/web/curate/speciesList/validateSpeciesList-body.jsp
+++ b/web/curate/speciesList/validateSpeciesList-body.jsp
@@ -90,7 +90,8 @@
             <table border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse; margin-bottom: 15px;">
                 <tr><th align="left">Total Rows Processed</th><td><%= report.getTotalInputRows() %></td></tr>
                 <tr><th align="left">Exact Matches</th><td style="color: green; font-weight: bold;"><%= report.getExactMatchCount() %></td></tr>
-                <tr><th align="left">Not Found / Ambiguous</th><td style="color: orange; font-weight: bold;"><%= report.getProblemCount() %></td></tr>
+                <tr><th align="left">Need attention</th><td style="color: orange; font-weight: bold;"><%= report.getNeedAttentionCount() %></td></tr>
+                <tr><th align="left">Informational</th><td style="color: #666; font-weight: bold;"><%= report.getInformationalCount() %></td></tr>
                 <tr><th align="left">Format Errors</th><td style="color: red; font-weight: bold;"><%= report.getFormatErrorCount() %></td></tr>
                 <% if (validateSpeciesListForm.isShowUnmatched()) { %>
                     <tr><th align="left">Unmatched AntWeb Taxa</th><td style="font-weight: bold;"><%= report.getUnmatchedCount() %></td></tr>
@@ -118,6 +119,8 @@
                         <th>Input Raw</th>
                         <th>Normalized Taxon Name</th>
                         <th>Status</th>
+                        <th>Category</th>
+                        <th>Fossil</th>
                         <th>Message</th>
                         <th>Suggestion</th>
                     </tr>
@@ -136,6 +139,8 @@
                             <td><%= item.getInputRaw() != null ? item.getInputRaw().replace("<", "&lt;").replace(">", "&gt;") : "" %></td>
                             <td><%= item.getNormalizedName() != null ? item.getNormalizedName() : "" %></td>
                             <td style="font-weight: bold;"><%= item.getStatus().name() %></td>
+                            <td style="font-weight: bold;"><%= item.getCategory() %></td>
+                            <td><%= item.getFossilDisplay() %></td>
                             <td><%= item.getMessage() %></td>
                             <% if (item.getSuggestion() != null && !item.getSuggestion().isEmpty()) { %>
                                 <td style="font-weight: bold; color: #000;"><%= item.getSuggestion() %>
@@ -153,7 +158,7 @@
 
             <% if (report.getFormatErrorCount() == 0 && report.getProblemCount() == 0) { %>
                 <div style="color: green; font-weight: bold; margin-top: 10px;">
-                    ✓ All rows matched valid extant taxa exactly.
+                    ✓ All rows matched valid taxa exactly.
                 </div>
             <% } %>
             


### PR DESCRIPTION
Propagate a fossil boolean through taxon lookups and fuzzy matching, and compute human-readable result categories. SpeciesListValidator now selects the fossil column and returns structured TaxonLookupResult/FuzzyMatch objects; lookup SQL prefers valid names. ValidateSpeciesResultItem gained lookupStatus, hasSuggestedValidName, fossil and category logic; ValidateSpeciesReport exposes NeedAttention/Informational counts and includes Category and Fossil in TSV output. The UI JSP was updated to show the new columns, and a unit test (ValidateSpeciesReportTest) was added. Also includes minor whitespace fixes in struts-configDbAnt.xml.

fixes #33