### PR TITLE
Add encoding detection and curator-friendly labels

### DIFF
--- a/src/org/calacademy/antweb/curate/speciesList/SpeciesListValidator.java
+++ b/src/org/calacademy/antweb/curate/speciesList/SpeciesListValidator.java
@@ -1,9 +1,13 @@
 package org.calacademy.antweb.curate.speciesList;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -286,7 +290,10 @@ public class SpeciesListValidator {
 
     private List<ParsedRow> parseStream(InputStream is, String charset) throws ValidationParseException, IOException {
         List<ParsedRow> results = new ArrayList<>();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(is, charset));
+        DecodedInput decodedInput = decodeInput(is, charset);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(
+                new ByteArrayInputStream(decodedInput.bytes, decodedInput.offset, decodedInput.bytes.length - decodedInput.offset),
+                decodedInput.charset));
         
         String headerLine = reader.readLine();
         if (headerLine == null) throw new ValidationParseException("File is empty.");
@@ -368,6 +375,84 @@ public class SpeciesListValidator {
         }
         
         return results;
+    }
+
+    private DecodedInput decodeInput(InputStream is, String fallbackCharset) throws IOException {
+        byte[] bytes = readAllBytes(is);
+        if (bytes.length >= 3
+                && (bytes[0] & 0xff) == 0xef
+                && (bytes[1] & 0xff) == 0xbb
+                && (bytes[2] & 0xff) == 0xbf) {
+            return new DecodedInput(bytes, 3, StandardCharsets.UTF_8);
+        }
+        if (bytes.length >= 2
+                && (bytes[0] & 0xff) == 0xff
+                && (bytes[1] & 0xff) == 0xfe) {
+            return new DecodedInput(bytes, 2, StandardCharsets.UTF_16LE);
+        }
+        if (bytes.length >= 2
+                && (bytes[0] & 0xff) == 0xfe
+                && (bytes[1] & 0xff) == 0xff) {
+            return new DecodedInput(bytes, 2, StandardCharsets.UTF_16BE);
+        }
+        Charset detected = detectUtf16WithoutBom(bytes);
+        if (detected != null) {
+            return new DecodedInput(bytes, 0, detected);
+        }
+        return new DecodedInput(bytes, 0, charsetOrUtf8(fallbackCharset));
+    }
+
+    private byte[] readAllBytes(InputStream is) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[4096];
+        int read;
+        while ((read = is.read(chunk)) != -1) {
+            buffer.write(chunk, 0, read);
+        }
+        return buffer.toByteArray();
+    }
+
+    private Charset detectUtf16WithoutBom(byte[] bytes) {
+        int limit = Math.min(bytes.length, 200);
+        if (limit < 20) return null;
+
+        int evenNulls = 0;
+        int oddNulls = 0;
+        int pairs = limit / 2;
+        for (int i = 0; i + 1 < limit; i += 2) {
+            if (bytes[i] == 0) evenNulls++;
+            if (bytes[i + 1] == 0) oddNulls++;
+        }
+        if (oddNulls > pairs / 3 && evenNulls == 0) {
+            return StandardCharsets.UTF_16LE;
+        }
+        if (evenNulls > pairs / 3 && oddNulls == 0) {
+            return StandardCharsets.UTF_16BE;
+        }
+        return null;
+    }
+
+    private Charset charsetOrUtf8(String charset) {
+        if (charset == null || charset.trim().isEmpty()) {
+            return StandardCharsets.UTF_8;
+        }
+        try {
+            return Charset.forName(charset);
+        } catch (Exception e) {
+            s_log.warn("Unsupported charset '" + charset + "'. Falling back to UTF-8.");
+            return StandardCharsets.UTF_8;
+        }
+    }
+
+    private static class DecodedInput {
+        final byte[] bytes;
+        final int offset;
+        final Charset charset;
+        DecodedInput(byte[] bytes, int offset, Charset charset) {
+            this.bytes = bytes;
+            this.offset = offset;
+            this.charset = charset;
+        }
     }
     
     private String safeGet(String[] t, int idx) {

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReport.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReport.java
@@ -44,11 +44,7 @@ public class ValidateSpeciesReport {
     public int getNeedAttentionCount() {
         int count = 0;
         for (ValidateSpeciesResultItem item : problems) {
-            String category = item.getCategory();
-            if (ValidateSpeciesResultItem.CATEGORY_SPELLING.equals(category)
-                    || ValidateSpeciesResultItem.CATEGORY_JUNIOR_SYNONYM.equals(category)
-                    || ValidateSpeciesResultItem.CATEGORY_COMBINATION_CHANGED.equals(category)
-                    || ValidateSpeciesResultItem.CATEGORY_NOT_FOUND.equals(category)) {
+            if (item.isNeedAttention()) {
                 count++;
             }
         }
@@ -69,7 +65,7 @@ public class ValidateSpeciesReport {
 
     public String generateTsvReport() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Row\tInput Raw\tNormalized Taxon Name\tStatus\tCategory\tFossil\tMessage\tSuggestion\n");
+        sb.append("Row\tInput\tInput Normalized\tComparison\tCategory\tFossil\tComment\tSuggestion\n");
         
         List<ValidateSpeciesResultItem> all = new ArrayList<>();
         all.addAll(formatErrors);

--- a/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesResultItem.java
+++ b/src/org/calacademy/antweb/curate/speciesList/ValidateSpeciesResultItem.java
@@ -47,6 +47,12 @@ public final class ValidateSpeciesResultItem {
     public String getLookupStatus() { return lookupStatus; }
     public boolean hasSuggestedValidName() { return hasSuggestedValidName; }
     public String getCategory() { return category; }
+    public boolean isNeedAttention() {
+        return CATEGORY_SPELLING.equals(category)
+                || CATEGORY_JUNIOR_SYNONYM.equals(category)
+                || CATEGORY_COMBINATION_CHANGED.equals(category)
+                || CATEGORY_NOT_FOUND.equals(category);
+    }
     public boolean isFossil() { return fossil; }
     public String getFossilDisplay() { return fossil ? "yes" : "no"; }
     public String getMessage() { return message; }

--- a/test/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReportTest.java
+++ b/test/org/calacademy/antweb/curate/speciesList/ValidateSpeciesReportTest.java
@@ -1,6 +1,12 @@
 package test.org.calacademy.antweb.curate.speciesList;
 
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import junit.framework.TestCase;
+import org.calacademy.antweb.curate.speciesList.SpeciesListValidator;
 import org.calacademy.antweb.curate.speciesList.ValidateSpeciesReport;
 import org.calacademy.antweb.curate.speciesList.ValidateSpeciesResultItem;
 
@@ -37,7 +43,7 @@ public class ValidateSpeciesReportTest extends TestCase {
         assertEquals(1, report.getExactMatchCount());
     }
 
-    public void testTsvIncludesCategoryAndFossilColumns() {
+    public void testTsvUsesCuratorFriendlyColumnNames() {
         ValidateSpeciesReport report = new ValidateSpeciesReport();
         report.addResult(new ValidateSpeciesResultItem(
                 2, "Acromyrmex\tbalzani", "Acromyrmex balzani",
@@ -46,8 +52,22 @@ public class ValidateSpeciesReportTest extends TestCase {
 
         String tsv = report.generateTsvReport();
 
-        assertTrue(tsv.startsWith("Row\tInput Raw\tNormalized Taxon Name\tStatus\tCategory\tFossil\tMessage\tSuggestion\n"));
+        assertTrue(tsv.startsWith("Row\tInput\tInput Normalized\tComparison\tCategory\tFossil\tComment\tSuggestion\n"));
         assertTrue(tsv.contains("2\tAcromyrmex  balzani\tAcromyrmex balzani\tAMBIGUOUS\tJunior synonym\tyes\tMatched a synonym.\tAcromyrmex validus\n"));
+    }
+
+    public void testParserAcceptsUtf16LittleEndianTextFiles() throws Exception {
+        String content = "subfamily\tgenus\tspecies\tsubspecies\r\n"
+                + "Myrmicinae\tAcanthognathus\tbrevicornis\t\r\n";
+        byte[] payload = withUtf16LeBom(content);
+
+        SpeciesListValidator validator = new SpeciesListValidator(null);
+        Method parseStream = SpeciesListValidator.class.getDeclaredMethod("parseStream", java.io.InputStream.class, String.class);
+        parseStream.setAccessible(true);
+
+        List rows = (List) parseStream.invoke(validator, new ByteArrayInputStream(payload), "UTF-8");
+
+        assertEquals(1, rows.size());
     }
 
     private static void assertCategory(String expected, ValidateSpeciesResultItem item) {
@@ -79,5 +99,14 @@ public class ValidateSpeciesReportTest extends TestCase {
                 1, "input", "",
                 ValidateSpeciesResultItem.Status.FORMAT_ERROR,
                 "", false, "Missing genus or species token.", "", false);
+    }
+
+    private static byte[] withUtf16LeBom(String value) {
+        byte[] text = value.getBytes(StandardCharsets.UTF_16LE);
+        byte[] withBom = new byte[text.length + 2];
+        withBom[0] = (byte) 0xff;
+        withBom[1] = (byte) 0xfe;
+        System.arraycopy(text, 0, withBom, 2, text.length);
+        return withBom;
     }
 }

--- a/web/curate/speciesList/validateSpeciesList-body.jsp
+++ b/web/curate/speciesList/validateSpeciesList-body.jsp
@@ -107,21 +107,27 @@
                 <html:form method="POST" action="validateSpeciesList.do">
                     <input type="hidden" name="action" value="downloadCorrected" />
                     <input type="hidden" name="showUnmatched" value="<%= validateSpeciesListForm.isShowUnmatched() %>" />
-                    <input type="submit" value="Download Corrected Curated Dataset" style="padding: 5px 15px; font-weight: bold; color: green;" />
+                    <input type="submit" value="Download Valid Subset" style="padding: 5px 15px; font-weight: bold; color: green;" />
                 </html:form>
             </div>
 
+            <% if (report.getNeedAttentionCount() > 0) { %>
+                <div style="border: 2px solid #d98200; background-color: #fff3cd; padding: 10px; margin-bottom: 15px; font-weight: bold;">
+                    Needs attention: <%= report.getNeedAttentionCount() %> rows require curator review. Sort or filter by Category in the downloaded TSV.
+                </div>
+            <% } %>
+
             <% if (report.getProblemCount() > 0 || report.getFormatErrorCount() > 0) { %>
-                <h3>Problems & Format Errors Log</h3>
+                <h3>Rows Needing Attention, Informational Notes & Format Errors</h3>
                 <table border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse; width: 100%;">
                     <tr style="background-color: #eee;">
                         <th>Row</th>
-                        <th>Input Raw</th>
-                        <th>Normalized Taxon Name</th>
-                        <th>Status</th>
+                        <th>Input</th>
+                        <th>Input Normalized</th>
+                        <th>Comparison</th>
                         <th>Category</th>
                         <th>Fossil</th>
-                        <th>Message</th>
+                        <th>Comment</th>
                         <th>Suggestion</th>
                     </tr>
                     
@@ -132,7 +138,7 @@
                     issues.sort((a, b) -> Integer.compare(a.getRowNum(), b.getRowNum()));
                     
                     for (ValidateSpeciesResultItem item : issues) { 
-                        String bg = item.getStatus() == ValidateSpeciesResultItem.Status.FORMAT_ERROR ? "#ffe6e6" : "#fff3cd";
+                        String bg = item.getStatus() == ValidateSpeciesResultItem.Status.FORMAT_ERROR ? "#ffe6e6" : (item.isNeedAttention() ? "#fff3cd" : "#f5f5f5");
                     %>
                         <tr style="background-color: <%= bg %>;">
                             <td><%= item.getRowNum() %></td>


### PR DESCRIPTION
Detect and handle input encodings (UTF-8/16 BOM and heuristics) when parsing species list files by adding decoding helpers (DecodedInput, readAllBytes, detectUtf16WithoutBom, charset fallback) in SpeciesListValidator. Change report column names and UX text to curator-friendly terms (e.g. "Row\tInput\tInput Normalized\tComparison\tCategory\tFossil\tComment\tSuggestion"). Introduce ValidateSpeciesResultItem.isNeedAttention() and use it in ValidateSpeciesReport.getNeedAttentionCount() and JSP row styling; add an attention banner and rename the download button to "Download Valid Subset". Update tests to expect the new TSV header and add a unit test to verify parsing of UTF-16LE files with BOM.