### PR TITLE
Add curator specimen list lookup tool

### DIFF
--- a/WEB-INF/struts-config.xml
+++ b/WEB-INF/struts-config.xml
@@ -224,6 +224,7 @@
   </form-bean>  
 
   <form-bean name="validateSpeciesListForm" type="org.calacademy.antweb.curate.speciesList.ValidateSpeciesListForm"/>
+  <form-bean name="specimenListLookupForm" type="org.calacademy.antweb.curate.specimen.SpecimenListLookupForm"/>
       
   </form-beans>
 
@@ -619,6 +620,15 @@ We would like to remove getChildImages.  Not needed now in the new UI
             input="/curate/speciesList/validateSpeciesList.jsp"
             name="validateSpeciesListForm">
       <forward name="validateSpeciesList" path="/curate/speciesList/validateSpeciesList.jsp" />
+    </action>
+
+    <action path="/specimenListLookup"
+            type="org.calacademy.antweb.curate.specimen.SpecimenListLookupAction"
+            scope="request"
+            validate="false"
+            input="/curate/specimen/specimenListLookup.jsp"
+            name="specimenListLookupForm">
+      <forward name="specimenListLookup" path="/curate/specimen/specimenListLookup.jsp" />
     </action>
 
     <action path="/speciesListTool"

--- a/build.xml
+++ b/build.xml
@@ -250,6 +250,7 @@ To successfully compile jsps from ant you must set this environment property:
 <target name="test" depends="compile">
   <junit printsummary="true" fork="true">
     <test name="test.org.calacademy.antweb.AntWebStrutsTest" />
+    <test name="test.org.calacademy.antweb.curate.specimen.SpecimenListLookupServiceTest" />
     <classpath>
       <pathelement location="${build.home}/WEB-INF/classes" />
       <pathelement location="${lib.home}" />

--- a/src/org/calacademy/antweb/Specimen.java
+++ b/src/org/calacademy/antweb/Specimen.java
@@ -146,125 +146,112 @@ public class Specimen extends Taxon implements Serializable, Comparable<Taxon>  
     }
 
 
+    public static String getTaxonomicInfoColumns() {
+        return "code, subfamily, speciesgroup, genus, subgenus, species, subspecies, type_status, country, adm1, adm2, island_country"
+                + ", localityName, collectionCode, bioregion, habitat, method, ownedby, collectedby"
+                + ", life_stage, caste, subcaste, locatedAt, localityCode, museum"
+                + ", access_group, access_login, last_modified, medium, determinedby"
+                + ", specimenNotes, dnaExtractionNotes, microhabitat"
+                + ", elevation, elevationMaxError, decimal_latitude, decimal_longitude, latlonmaxerror"
+                + ", datedetermined, datedeterminedstr, localitynotes, collectionnotes"
+                + ", datecollectedstart, datecollectedend, datecollectedstartStr, datecollectedendStr"
+                + ", family, kingdom_name, phylum_name, class_name, order_name"
+                + ", taxon_name, image_count, original_taxon_name, line_num, is_introduced"
+                + ", created, backup_file_name, upload_id, flag, issue, taxonworks_co_id, other";
+    }
+
+    public static Specimen fromTaxonomicInfoResult(ResultSet rset) throws SQLException {
+        Specimen specimen = new Specimen();
+        specimen.setCode(rset.getString("code"));
+        specimen.populateTaxonomicInfo(rset);
+        specimen.setRank("specimen");
+        return specimen;
+    }
+
     public void setTaxonomicInfo(Connection connection) throws SQLException {
         Statement stmt = null;
         ResultSet rset = null;
         try {
-            String theQuery =
-                "select subfamily, speciesgroup, genus, subgenus, species, subspecies, type_status, country, adm1, adm2, island_country"  // was province, county"
-                    + ", localityName, collectionCode, bioregion, habitat, method, ownedby, collectedby"
-                    + ", life_stage, caste, subcaste"
-                    + ", locatedAt, localityCode, museum "
-                    
-                    //Added by Mark, Aug, 2011.
-                    + ", access_group, access_login, last_modified, medium, determinedby " 
-                    + ", specimenNotes, dnaExtractionNotes, microhabitat" //, datescollected "
-                    
-                    // Locality info added for the crazy link we create.
-                    + ", elevation, elevationMaxError, decimal_latitude, decimal_longitude, latlonmaxerror"  // locxyaccuracy " 
-                    + ", datedetermined, datedeterminedstr, localitynotes, collectionnotes"
-                    + ", datecollectedstart, datecollectedend, datecollectedstartStr, datecollectedendStr"
-                    + ", family, kingdom_name, phylum_name, class_name, order_name "
-                    //+ ", parent_taxon_id, image_count "
-                    + ", taxon_name, image_count "
-                    + ", original_taxon_name, line_num, is_introduced" //, is_endemic "
-                    + ", created "
-                    + ", backup_file_name "
-                    + ", upload_id "
-                    + ", flag, issue, taxonworks_co_id, other"
-                    + " from specimen where code='" + AntFormatter.escapeQuotes(getCode())
-                    + "'";
+            String theQuery = "select " + getTaxonomicInfoColumns()
+                    + " from specimen where code='" + AntFormatter.escapeQuotes(getCode()) + "'";
 
             stmt = DBUtil.getStatement(connection, "setTaxonomicInfo()");
             rset = stmt.executeQuery(theQuery);
 
             while (rset.next()) {
-                setSubfamily(rset.getString("subfamily"));
-                setSpeciesGroup(rset.getString("speciesgroup"));
-                setGenus(rset.getString("genus"));
-                setSubgenus(rset.getString("subgenus"));
-                //A.log("setTaxonomicInfo() subgenus:" + getSubgenus());
-
-                setSpecies(rset.getString("species"));
-                setSubspecies(rset.getString("subspecies"));
-                setTypeStatus(rset.getString("type_status"));
-                setCountry(rset.getString("country"));
-                setAdm1(rset.getString("adm1"));
-                setAdm2(rset.getString("adm2"));
-                setIslandCountry(rset.getString("island_country"));
-                setLocalityName(rset.getString("localityName"));
-                setCollectionCode(rset.getString("collectionCode"));
-                setBioregion(rset.getString("bioregion"));
-                setHabitat(rset.getString("habitat"));
-                setMethod(rset.getString("method"));
-                setOwnedBy(rset.getString("ownedby"));
-                setCollectedBy(rset.getString("collectedby"));
-
-                setLifeStage(rset.getString("life_stage"));
-                setCaste(rset.getString("caste"));
-                setSubcaste(rset.getString("subcaste"));
-
-                setLocatedAt(rset.getString("locatedAt"));
-                setLocalityCode(rset.getString("localityCode"));
-                setLastModified(rset.getTimestamp("last_modified"));
-                setMedium(rset.getString("medium"));
-                setDeterminedBy(rset.getString("determinedby"));
-                setSpecimenNotes(rset.getString("specimenNotes"));
-                setDnaExtractionNotes(rset.getString("dnaExtractionNotes"));
-                setMicrohabitat(rset.getString("microhabitat"));
-                
-                // The above is poor design, discontinued.  Be explicit.
-                //setDatesCollected(rset.getString("datescollected"));
-                setDecimalLatitude(rset.getFloat("decimal_latitude"));
-                setDecimalLongitude(rset.getFloat("decimal_longitude"));
-                //setLocXYAccuracy(rset.getString("locxyaccuracy"));
-                setLatLonMaxError(rset.getString("latlonmaxerror"));
-                setElevation(rset.getString("elevation"));
-                setElevationMaxError(rset.getString("elevationmaxerror"));
-                setDateDetermined(rset.getString("datedetermined"));
-                setDateDeterminedStr(rset.getString("datedeterminedStr"));
-                setLocalityNotes(rset.getString("localitynotes"));
-                setCollectionNotes(rset.getString("collectionnotes"));
-                setDateCollectedStart(rset.getString("datecollectedstart"));
-                setDateCollectedEnd(rset.getString("datecollectedend"));
-                setDateCollectedStartStr(rset.getString("datecollectedstartstr"));
-                setDateCollectedEndStr(rset.getString("datecollectedendstr"));
-                setKingdomName(rset.getString("kingdom_name"));
-                setPhylumName(rset.getString("phylum_name"));
-                setClassName(rset.getString("class_name"));
-                setOrderName(rset.getString("order_name"));
-                setFamily(rset.getString("family"));         
-                //setParentTaxonId(rset.getInt("parent_taxon_id"));   
-                setParentTaxonName(rset.getString("taxon_name"));
-                setImageCount(rset.getInt("image_count"));
-                setOriginalTaxonName(rset.getString("original_taxon_name"));
-                setLineNum(rset.getInt("line_num"));
-                setCreated(rset.getTimestamp("created"));
-                setIsIntroduced(rset.getInt("is_introduced") == 1);
-                //setIsEndemic((rset.getInt("is_endemic") == 1) ? true : false);                
-                setMuseumCode(rset.getString("museum"));
-                setBackupFileName(rset.getString("backup_file_name"));
-                setUploadId(rset.getInt("upload_id"));
-                
-                setGroupId(rset.getInt("access_group"));
-                setCuratorId(rset.getInt("access_login"));
-                
-                setFlag(rset.getString("flag"));
-                setIssue(rset.getString("issue"));
-                setTaxonworksCollectionObjectID(rset.getString("taxonworks_co_id"));
-
-                setDetailXml(rset.getString("other"));
-
-                //goSetStatus(connection);
-                goSetDetails();
-                            
-              //A.log("setTaxonomicInfo() code:" + getCode() + " uploadId:" + getUploadId() + " query:" + theQuery);      
+                populateTaxonomicInfo(rset);
             }
         } catch (SQLException e) {
             s_log.error("setTaxonomicInfo() e:" + e);
         } finally {
             DBUtil.close(stmt, rset, this, "setTaxonomicInfo()");
         }
+    }
+
+    private void populateTaxonomicInfo(ResultSet rset) throws SQLException {
+        setSubfamily(rset.getString("subfamily"));
+        setSpeciesGroup(rset.getString("speciesgroup"));
+        setGenus(rset.getString("genus"));
+        setSubgenus(rset.getString("subgenus"));
+        setSpecies(rset.getString("species"));
+        setSubspecies(rset.getString("subspecies"));
+        setTypeStatus(rset.getString("type_status"));
+        setCountry(rset.getString("country"));
+        setAdm1(rset.getString("adm1"));
+        setAdm2(rset.getString("adm2"));
+        setIslandCountry(rset.getString("island_country"));
+        setLocalityName(rset.getString("localityName"));
+        setCollectionCode(rset.getString("collectionCode"));
+        setBioregion(rset.getString("bioregion"));
+        setHabitat(rset.getString("habitat"));
+        setMethod(rset.getString("method"));
+        setOwnedBy(rset.getString("ownedby"));
+        setCollectedBy(rset.getString("collectedby"));
+        setLifeStage(rset.getString("life_stage"));
+        setCaste(rset.getString("caste"));
+        setSubcaste(rset.getString("subcaste"));
+        setLocatedAt(rset.getString("locatedAt"));
+        setLocalityCode(rset.getString("localityCode"));
+        setLastModified(rset.getTimestamp("last_modified"));
+        setMedium(rset.getString("medium"));
+        setDeterminedBy(rset.getString("determinedby"));
+        setSpecimenNotes(rset.getString("specimenNotes"));
+        setDnaExtractionNotes(rset.getString("dnaExtractionNotes"));
+        setMicrohabitat(rset.getString("microhabitat"));
+        setDecimalLatitude(rset.getFloat("decimal_latitude"));
+        setDecimalLongitude(rset.getFloat("decimal_longitude"));
+        setLatLonMaxError(rset.getString("latlonmaxerror"));
+        setElevation(rset.getString("elevation"));
+        setElevationMaxError(rset.getString("elevationmaxerror"));
+        setDateDetermined(rset.getString("datedetermined"));
+        setDateDeterminedStr(rset.getString("datedeterminedStr"));
+        setLocalityNotes(rset.getString("localitynotes"));
+        setCollectionNotes(rset.getString("collectionnotes"));
+        setDateCollectedStart(rset.getString("datecollectedstart"));
+        setDateCollectedEnd(rset.getString("datecollectedend"));
+        setDateCollectedStartStr(rset.getString("datecollectedstartstr"));
+        setDateCollectedEndStr(rset.getString("datecollectedendstr"));
+        setKingdomName(rset.getString("kingdom_name"));
+        setPhylumName(rset.getString("phylum_name"));
+        setClassName(rset.getString("class_name"));
+        setOrderName(rset.getString("order_name"));
+        setFamily(rset.getString("family"));
+        setParentTaxonName(rset.getString("taxon_name"));
+        setImageCount(rset.getInt("image_count"));
+        setOriginalTaxonName(rset.getString("original_taxon_name"));
+        setLineNum(rset.getInt("line_num"));
+        setCreated(rset.getTimestamp("created"));
+        setIsIntroduced(rset.getInt("is_introduced") == 1);
+        setMuseumCode(rset.getString("museum"));
+        setBackupFileName(rset.getString("backup_file_name"));
+        setUploadId(rset.getInt("upload_id"));
+        setGroupId(rset.getInt("access_group"));
+        setCuratorId(rset.getInt("access_login"));
+        setFlag(rset.getString("flag"));
+        setIssue(rset.getString("issue"));
+        setTaxonworksCollectionObjectID(rset.getString("taxonworks_co_id"));
+        setDetailXml(rset.getString("other"));
+        goSetDetails();
     }
 
     private void goSetDetails() {

--- a/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupAction.java
+++ b/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupAction.java
@@ -1,0 +1,121 @@
+package org.calacademy.antweb.curate.specimen;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.upload.FormFile;
+import org.calacademy.antweb.Specimen;
+import org.calacademy.antweb.home.SpecimenDb;
+import org.calacademy.antweb.util.Check;
+import org.calacademy.antweb.util.DBUtil;
+import org.calacademy.antweb.util.HttpUtil;
+
+public class SpecimenListLookupAction extends org.apache.struts.action.Action {
+    private static final Log s_log = LogFactory.getLog(SpecimenListLookupAction.class);
+
+    @Override
+    public ActionForward execute(ActionMapping mapping, ActionForm form,
+            HttpServletRequest request, HttpServletResponse response) {
+        ActionForward curatorCheck = Check.curator(request, mapping);
+        if (curatorCheck != null) return curatorCheck;
+
+        SpecimenListLookupForm lookupForm = (SpecimenListLookupForm) form;
+        FormFile uploadedFile = lookupForm.getFile();
+        if (!HttpUtil.isPost(request)) return mapping.findForward("specimenListLookup");
+        if (uploadedFile == null || uploadedFile.getFileSize() == 0) {
+            request.setAttribute("message", "Choose a specimen list file before submitting.");
+            return mapping.findForward("specimenListLookup");
+        }
+
+        String filenameError = SpecimenListLookupService.validateFilename(uploadedFile.getFileName());
+        if (filenameError != null) {
+            request.setAttribute("message", filenameError);
+            return mapping.findForward("specimenListLookup");
+        }
+        if (uploadedFile.getFileSize() > SpecimenListLookupService.MAX_FILE_SIZE) {
+            request.setAttribute("message", "File is too large. Maximum size is 5 MB.");
+            return mapping.findForward("specimenListLookup");
+        }
+
+        Connection connection = null;
+        Path outputFile = null;
+        try {
+            DataSource dataSource = getDataSource(request, "longConPool");
+            connection = DBUtil.getConnection(dataSource, "SpecimenListLookupAction.execute()");
+            if (connection == null) {
+                request.setAttribute("message", "Could not obtain a database connection.");
+                return mapping.findForward("specimenListLookup");
+            }
+            connection.setReadOnly(true);
+
+            outputFile = Files.createTempFile("antweb-specimen-list-", ".tsv");
+            SpecimenDb specimenDb = new SpecimenDb(connection);
+            SpecimenListLookupSource source = new SpecimenListLookupSource() {
+                @Override
+                public Map<String, Specimen> findByCodes(List<String> codes) throws SQLException {
+                    return specimenDb.getSpecimensByCodes(codes);
+                }
+            };
+
+            SpecimenListLookupResult result;
+            try (Writer writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8)) {
+                result = new SpecimenListLookupService().lookup(
+                        uploadedFile.getInputStream(), source, writer);
+            }
+            if (!result.isSuccess()) {
+                request.setAttribute("lookupResult", result);
+                request.setAttribute("message", "The lookup could not be completed. Correct the listed issues and try again.");
+                return mapping.findForward("specimenListLookup");
+            }
+
+            response.setContentType("text/tab-separated-values; charset=UTF-8");
+            response.setHeader("Content-Disposition", "attachment; filename=\"specimen_list_lookup.tsv\"");
+            response.setHeader("Cache-Control", "no-store");
+            response.setHeader("X-Content-Type-Options", "nosniff");
+            response.setContentLength((int) Files.size(outputFile));
+            Files.copy(outputFile, response.getOutputStream());
+            response.getOutputStream().flush();
+            return null;
+        } catch (SQLException e) {
+            s_log.error("Specimen list lookup database error", e);
+            request.setAttribute("message", "A database error occurred during the lookup. Please try again.");
+            return mapping.findForward("specimenListLookup");
+        } catch (IOException e) {
+            s_log.error("Specimen list lookup file error", e);
+            request.setAttribute("message", "The specimen list file could not be processed. Please try again.");
+            return mapping.findForward("specimenListLookup");
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.setReadOnly(false);
+                } catch (SQLException e) {
+                    s_log.error("Failed to reset specimen lookup connection", e);
+                }
+            }
+            DBUtil.close(connection, this, "SpecimenListLookupAction.execute()");
+            if (outputFile != null) {
+                try {
+                    Files.deleteIfExists(outputFile);
+                } catch (IOException e) {
+                    s_log.warn("Could not delete specimen lookup temporary file", e);
+                }
+            }
+        }
+    }
+}

--- a/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupForm.java
+++ b/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupForm.java
@@ -1,0 +1,24 @@
+package org.calacademy.antweb.curate.specimen;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.upload.FormFile;
+
+public class SpecimenListLookupForm extends ActionForm {
+    private FormFile file;
+
+    public FormFile getFile() {
+        return file;
+    }
+
+    public void setFile(FormFile file) {
+        this.file = file;
+    }
+
+    @Override
+    public void reset(ActionMapping mapping, HttpServletRequest request) {
+        file = null;
+    }
+}

--- a/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupResult.java
+++ b/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupResult.java
@@ -1,0 +1,42 @@
+package org.calacademy.antweb.curate.specimen;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SpecimenListLookupResult {
+    private static final int MAX_DISPLAYED_ERRORS = 100;
+
+    private final List<String> errors = new ArrayList<>();
+    private int errorCount;
+    private int rowCount;
+
+    public boolean isSuccess() {
+        return errorCount == 0;
+    }
+
+    public void addError(String error) {
+        errorCount++;
+        if (errors.size() < MAX_DISPLAYED_ERRORS) errors.add(error);
+    }
+
+    public List<String> getErrors() {
+        return Collections.unmodifiableList(errors);
+    }
+
+    public int getErrorCount() {
+        return errorCount;
+    }
+
+    public int getRowCount() {
+        return rowCount;
+    }
+
+    public void setRowCount(int rowCount) {
+        this.rowCount = rowCount;
+    }
+
+    public boolean hasAdditionalErrors() {
+        return errorCount > errors.size();
+    }
+}

--- a/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupService.java
+++ b/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupService.java
@@ -1,0 +1,124 @@
+package org.calacademy.antweb.curate.specimen;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.calacademy.antweb.Specimen;
+
+public class SpecimenListLookupService {
+    public static final int MAX_ROWS = 100000;
+    public static final int MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    private final int maxRows;
+
+    public SpecimenListLookupService() {
+        this(MAX_ROWS);
+    }
+
+    public SpecimenListLookupService(int maxRows) {
+        this.maxRows = maxRows;
+    }
+
+    public SpecimenListLookupResult lookup(InputStream input, SpecimenListLookupSource source,
+            Writer output) throws IOException, SQLException {
+        SpecimenListLookupResult result = new SpecimenListLookupResult();
+        List<CodeLine> codeLines = readCodes(input, result);
+        result.setRowCount(codeLines.size());
+        if (!result.isSuccess()) return result;
+
+        LinkedHashMap<String, String> uniqueCodes = new LinkedHashMap<>();
+        for (CodeLine codeLine : codeLines) {
+            uniqueCodes.putIfAbsent(normalize(codeLine.code), codeLine.code);
+        }
+
+        Map<String, Specimen> specimens = source.findByCodes(new ArrayList<>(uniqueCodes.values()));
+        for (CodeLine codeLine : codeLines) {
+            if (!specimens.containsKey(normalize(codeLine.code))) {
+                result.addError("Line " + codeLine.lineNumber + ": specimen code was not found.");
+            }
+        }
+        if (!result.isSuccess()) return result;
+
+        output.write(Specimen.getTabDelimHeader());
+        output.write('\n');
+        for (CodeLine codeLine : codeLines) {
+            Specimen specimen = specimens.get(normalize(codeLine.code));
+            specimen.setCode(codeLine.code);
+            output.write(specimen.getTabDelimString());
+            output.write('\n');
+        }
+        output.flush();
+        return result;
+    }
+
+    public static String validateFilename(String filename) {
+        if (filename == null || !filename.toLowerCase(Locale.ROOT).endsWith(".txt")) {
+            return "File must be a plain .txt file.";
+        }
+        if (!filename.toLowerCase(Locale.ROOT).contains("specimen")) {
+            return "Filename must contain 'specimen'.";
+        }
+        return null;
+    }
+
+    private List<CodeLine> readCodes(InputStream input, SpecimenListLookupResult result)
+            throws IOException {
+        List<CodeLine> codes = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            String line;
+            int lineNumber = 0;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if (lineNumber == 1 && line.startsWith("\ufeff")) line = line.substring(1);
+                String code = line.trim();
+                if (code.isEmpty()) continue;
+                if (codes.size() == maxRows) {
+                    result.addError("File contains more than " + maxRows + " specimen codes.");
+                    return codes;
+                }
+                if (containsWhitespace(code)) {
+                    result.addError("Line " + lineNumber
+                            + ": specimen code contains whitespace, which is not permitted.");
+                    continue;
+                }
+                codes.add(new CodeLine(lineNumber, code));
+            }
+        }
+        if (codes.isEmpty() && result.isSuccess()) {
+            result.addError("File must contain at least one specimen code.");
+        }
+        return codes;
+    }
+
+    private static boolean containsWhitespace(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isWhitespace(value.charAt(i))) return true;
+        }
+        return false;
+    }
+
+    private static String normalize(String code) {
+        return code.toLowerCase(Locale.ROOT);
+    }
+
+    private static class CodeLine {
+        private final int lineNumber;
+        private final String code;
+
+        private CodeLine(int lineNumber, String code) {
+            this.lineNumber = lineNumber;
+            this.code = code;
+        }
+    }
+}

--- a/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupSource.java
+++ b/src/org/calacademy/antweb/curate/specimen/SpecimenListLookupSource.java
@@ -1,0 +1,11 @@
+package org.calacademy.antweb.curate.specimen;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import org.calacademy.antweb.Specimen;
+
+public interface SpecimenListLookupSource {
+    Map<String, Specimen> findByCodes(List<String> codes) throws SQLException;
+}

--- a/src/org/calacademy/antweb/home/SpecimenDb.java
+++ b/src/org/calacademy/antweb/home/SpecimenDb.java
@@ -76,6 +76,38 @@ public class SpecimenDb extends AntwebDb {
       return specimen;
     }
 
+    public java.util.Map<String, Specimen> getSpecimensByCodes(List<String> codes) throws SQLException {
+        java.util.Map<String, Specimen> specimens = new HashMap<>();
+        final int batchSize = 500;
+
+        for (int start = 0; start < codes.size(); start += batchSize) {
+            int end = Math.min(start + batchSize, codes.size());
+            List<String> batch = codes.subList(start, end);
+            StringBuilder placeholders = new StringBuilder();
+            for (int i = 0; i < batch.size(); i++) {
+                if (i > 0) placeholders.append(',');
+                placeholders.append('?');
+            }
+
+            String query = "select " + Specimen.getTaxonomicInfoColumns()
+                    + " from specimen where code in (" + placeholders + ")";
+            PreparedStatement stmt = null;
+            ResultSet rset = null;
+            try {
+                stmt = DBUtil.getPreparedStatement(getConnection(), "getSpecimensByCodes()", query);
+                for (int i = 0; i < batch.size(); i++) stmt.setString(i + 1, batch.get(i));
+                rset = stmt.executeQuery();
+                while (rset.next()) {
+                    Specimen specimen = Specimen.fromTaxonomicInfoResult(rset);
+                    specimens.put(specimen.getCode().toLowerCase(Locale.ROOT), specimen);
+                }
+            } finally {
+                DBUtil.close(stmt, rset, this, "getSpecimensByCodes()");
+            }
+        }
+        return specimens;
+    }
+
     public ArrayList<String> getAntwebSpecimenCodes(String family) throws SQLException {
         Overview overview = OverviewMgr.getOverview(Project.ALLANTWEBANTS);
         return getAntwebSpecimenCodes(overview, family, null);

--- a/test/org/calacademy/antweb/curate/specimen/SpecimenListLookupServiceTest.java
+++ b/test/org/calacademy/antweb/curate/specimen/SpecimenListLookupServiceTest.java
@@ -1,0 +1,119 @@
+package test.org.calacademy.antweb.curate.specimen;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+import org.calacademy.antweb.Specimen;
+import org.calacademy.antweb.curate.specimen.SpecimenListLookupResult;
+import org.calacademy.antweb.curate.specimen.SpecimenListLookupService;
+import org.calacademy.antweb.curate.specimen.SpecimenListLookupSource;
+
+public class SpecimenListLookupServiceTest extends TestCase {
+
+    public void testValidLookupPreservesHeaderOrderDuplicatesAndInputCase() throws Exception {
+        RecordingSource source = new RecordingSource();
+        source.add(specimen("casent0104501", "myrmicinaetest species"));
+        source.add(specimen("casent0104502", "myrmicinaeother species"));
+
+        String input = "\ufeffCASENT0104501\n\ncasent0104502\nCASENT0104501\n";
+        StringWriter output = new StringWriter();
+
+        SpecimenListLookupResult result = new SpecimenListLookupService().lookup(
+                stream(input), source, output);
+
+        assertTrue(result.isSuccess());
+        assertEquals(3, result.getRowCount());
+        assertEquals(2, source.requestedCodes.size());
+
+        String[] lines = output.toString().split("\n");
+        assertEquals(Specimen.getTabDelimHeader(), lines[0]);
+        assertTrue(lines[1].startsWith("CASENT0104501\t"));
+        assertTrue(lines[2].startsWith("casent0104502\t"));
+        assertTrue(lines[3].startsWith("CASENT0104501\t"));
+    }
+
+    public void testMissingCodeProducesErrorsAndNoDownload() throws Exception {
+        RecordingSource source = new RecordingSource();
+        source.add(specimen("casent0104501", "myrmicinaetest species"));
+        StringWriter output = new StringWriter();
+
+        SpecimenListLookupResult result = new SpecimenListLookupService().lookup(
+                stream("casent0104501\nmissing001\n"), source, output);
+
+        assertFalse(result.isSuccess());
+        assertEquals(1, result.getErrorCount());
+        assertEquals("Line 2: specimen code was not found.", result.getErrors().get(0));
+        assertEquals("", output.toString());
+    }
+
+    public void testWhitespaceAndEmptyFilesAreRejectedBeforeLookup() throws Exception {
+        RecordingSource source = new RecordingSource();
+        SpecimenListLookupService service = new SpecimenListLookupService();
+
+        SpecimenListLookupResult malformed = service.lookup(
+                stream("casent 0104501\ncasent\t0104502\n"), source, new StringWriter());
+        assertFalse(malformed.isSuccess());
+        assertEquals(2, malformed.getErrorCount());
+        assertEquals(0, source.calls);
+
+        SpecimenListLookupResult empty = service.lookup(
+                stream("\n  \n"), source, new StringWriter());
+        assertFalse(empty.isSuccess());
+        assertEquals("File must contain at least one specimen code.", empty.getErrors().get(0));
+        assertEquals(0, source.calls);
+    }
+
+    public void testConfiguredRowLimitIsEnforced() throws Exception {
+        SpecimenListLookupService service = new SpecimenListLookupService(2);
+        RecordingSource source = new RecordingSource();
+
+        SpecimenListLookupResult result = service.lookup(
+                stream("one\ntwo\nthree\n"), source, new StringWriter());
+
+        assertFalse(result.isSuccess());
+        assertEquals("File contains more than 2 specimen codes.", result.getErrors().get(0));
+        assertEquals(0, source.calls);
+    }
+
+    public void testFilenameValidationIsCaseInsensitive() {
+        assertNull(SpecimenListLookupService.validateFilename("My_Specimens.txt"));
+        assertEquals("Filename must contain 'specimen'.",
+                SpecimenListLookupService.validateFilename("codes.txt"));
+        assertEquals("File must be a plain .txt file.",
+                SpecimenListLookupService.validateFilename("my_specimens.tsv"));
+    }
+
+    private static ByteArrayInputStream stream(String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Specimen specimen(String code, String taxonName) {
+        Specimen specimen = new Specimen();
+        specimen.setCode(code);
+        specimen.setParentTaxonName(taxonName);
+        return specimen;
+    }
+
+    private static class RecordingSource implements SpecimenListLookupSource {
+        private final Map<String, Specimen> specimens = new LinkedHashMap<>();
+        private final List<String> requestedCodes = new ArrayList<>();
+        private int calls;
+
+        void add(Specimen specimen) {
+            specimens.put(specimen.getCode().toLowerCase(), specimen);
+        }
+
+        @Override
+        public Map<String, Specimen> findByCodes(List<String> codes) {
+            calls++;
+            requestedCodes.addAll(codes);
+            return specimens;
+        }
+    }
+}

--- a/web/curate/curate-body.jsp
+++ b/web/curate/curate-body.jsp
@@ -519,7 +519,13 @@ Upload Curator File
         <div class="admin_action_item">
           <div class="action_desc">
             &nbsp;&nbsp;&nbsp;<a href="<%= AntwebProps.getDomainApp() %>/validateSpeciesList.do">Validate Species List (Pre-flight checker)</a>
-          </div>  
+          </div>
+          <div class="clear"></div>
+        </div>
+        <div class="admin_action_item">
+          <div class="action_desc">
+            &nbsp;&nbsp;&nbsp;<a href="<%= AntwebProps.getDomainApp() %>/specimenListLookup.do">Specimen List Lookup</a>
+          </div>
           <div class="clear"></div>
         </div>
     </div>
@@ -696,92 +702,6 @@ if (speciesListList != null && !speciesListList.isEmpty()) { %>
 <% } %>
 
 
-<%
-    if (accessLogin.isAdmin()) {
-%>
-
-<div class="admin_action_item">
-    <div style="float:left;">
-        <h2>Other Functions</h2>
-    </div>
-    <div class="clear"></div>
-</div>
-
-
-<% // Edit Region content removed %>
-
-<br>
-<!-- Upload a File to a Folder
-<html:form method="POST" action="upload.do" enctype="multipart/form-data">
-    <input type="hidden" name="ancFileDirectory" value="none" />
-    <input type="hidden" name="updateAdvanced" value="no" />
-    <input type="hidden" name="updateFieldGuide" value="none" />
-    <input type="hidden" name="images" value="no" />
-    <input type="hidden" name="outputFileName" value="" />
-    <input type="hidden" name="successkey" value="null" />
-    <div class="admin_action_module">
-        <div class="admin_action_item">
-            <div class="action_desc"><b>Upload</b> a File to Folder:</div>
-            <div class="action_dropdown">
-  <html:select property="homePageDirectory">
-	<html:option value="curator">Curator Dir</html:option>
-< % if (accessLogin.isAdmin()) { % >
-		<html:option value="homepage">AntWeb Home Page</html:option>
-< % } % >
-
-	<% if (projList != null) {
-	     for (SpeciesListable s : projList) { 
-	       Project p = ProjectMgr.getProject(s.getName());
-	       if (p == null) {
-	         //A.log("curate-body.jsp 2 p is null for:" + s.getName());
-	       } else { %>
-             <option value="< %= p.getRoot() % >">< %= p.getTitle() % ></option>
-	    <% }
-	     }
-	   } %>
-	
-  </html:select>
-            </div>
-            <div class="action_browse">
-  <html:file property="theFile2" />
-            </div>
-            <div class="clear"></div>
-
-            <div class="align_right"><input border="0" type="image" src="<%= domainApp %>/image/grey_submit.png" width="77" height="23" value="Submit"></div>
-            <div class="clear"></div>
-        </div>
-    </div>
-</html:form>
--->
-
-
-<!-- Data File Upload -->
-<% if (accessLogin.isCurator()) { %>
-<html:form method="POST" action="upload.do" enctype="multipart/form-data">
-    <input type="hidden" name="ancFileDirectory" value="none" />
-    <input type="hidden" name="updateAdvanced" value="no" />
-    <input type="hidden" name="updateFieldGuide" value="none" />
-    <input type="hidden" name="images" value="no" />
-    <input type="hidden" name="outputFileName" value="" />
-    <input type="hidden" name="successkey" value="null" />
-    <div class="admin_action_module">
-        <div class="admin_action_item">
-            <div class="action_desc"><b>Upload</b> Data File<br>&nbsp;&nbsp;&nbsp;For specimen list lookup: upload a .txt file with 'specimen' in the filename (one specimen code per line, no spaces)<br></div>
-            <div class="action_browse">
-  <html:file property="testFile" />
-            </div>
-            <div class="clear"></div>
-            <div class="align_right"><input border="0" type="image" src="<%= domainApp %>/image/grey_submit.png" width="77" height="23" value="Submit"></div>
-            <div class="clear"></div>
-        </div>
-    </div>
-</html:form>
-<% } %>
-
-
-<% }  // isAdmin() %>
-
-
 </div>
 
 <div class="admin_right">
@@ -810,4 +730,3 @@ if (speciesListList != null && !speciesListList.isEmpty()) { %>
 <%@include file="/curate/curatorLinks.jsp" %>
 	  
 </div>
-

--- a/web/curate/specimen/specimenListLookup-body.jsp
+++ b/web/curate/specimen/specimenListLookup-body.jsp
@@ -1,0 +1,106 @@
+<%@ page language="java" %>
+<%@ page errorPage="/error.jsp" %>
+<%@ page import="org.calacademy.antweb.curate.specimen.SpecimenListLookupResult" %>
+<%@ page import="org.calacademy.antweb.util.AntwebProps" %>
+<%@ page import="java.util.List" %>
+
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+
+<%
+    String domainApp = AntwebProps.getDomainApp();
+    String message = (String) request.getAttribute("message");
+    SpecimenListLookupResult result = (SpecimenListLookupResult) request.getAttribute("lookupResult");
+%>
+
+<div class="admin_left">
+    <h1>Specimen List Lookup</h1>
+    <div style="color:#666; font-style:italic; margin-bottom:20px;">
+        Read-Only tool. Safe to use for reconciliation workflows. No database modifications will occur.
+    </div>
+
+    <% if (message != null && !message.isEmpty()) { %>
+        <div role="alert" style="border:1px solid #b30000; padding:10px; color:#b30000; background-color:#fee; margin-bottom:20px; font-weight:bold;">
+            <%= message %>
+            <% if (result != null) { %>
+                <ul style="margin-bottom:0;">
+                    <% for (String error : result.getErrors()) { %>
+                        <li><%= error %></li>
+                    <% } %>
+                    <% if (result.hasAdditionalErrors()) { %>
+                        <li><%= result.getErrorCount() - result.getErrors().size() %> additional errors are not displayed.</li>
+                    <% } %>
+                </ul>
+            <% } %>
+        </div>
+    <% } %>
+
+    <div class="admin_action_module">
+        <div class="admin_action_item">
+            <h2>Lookup Instructions</h2>
+            <p>Upload a plain <b>.txt</b> file containing specimen codes. The lookup returns a tab-delimited file with the specimen details stored in AntWeb.</p>
+            <ul>
+                <li>The filename must contain <b><code>specimen</code></b>.</li>
+                <li>Good filename: <code>my_specimens.txt</code></li>
+                <li>Bad filename: <code>codes.txt</code></li>
+                <li>Enter one specimen code per line.</li>
+                <li>Do not include spaces or tabs in specimen codes.</li>
+                <li>Maximum: <b>5 MB and 100,000 specimen codes</b>, whichever limit is reached first.</li>
+            </ul>
+
+            <p><b>Example file contents:</b></p>
+            <div style="background-color:#f5f5f5; padding:10px; margin:5px 0 15px 0; font-family:monospace;">
+                casent0104501<br>
+                casent0104502<br>
+                casent0179915
+            </div>
+
+            <p><a href="<%= domainApp %>/data/specimen_list_lookup_template.txt" download>Download Template File</a></p>
+        </div>
+    </div>
+
+    <div class="admin_action_module">
+        <div class="admin_action_item">
+            <h2>Upload File</h2>
+            <html:form method="POST" action="specimenListLookup.do" enctype="multipart/form-data"
+                    styleId="specimenLookupForm" onsubmit="return validateSpecimenLookupFile();">
+                <div style="margin-bottom:15px;">
+                    <label for="specimenFile" style="display:block; font-weight:bold; margin-bottom:5px;">Choose specimen list file</label>
+                    <html:file property="file" styleId="specimenFile" accept=".txt" />
+                    <div id="specimenFilenameError" role="alert" aria-live="polite"
+                            style="display:none; color:#b30000; font-weight:bold; margin-top:8px;"></div>
+                </div>
+                <div class="align_left">
+                    <input type="submit" value="Run Specimen Lookup" style="padding:5px 15px;" />
+                </div>
+                <div class="clear"></div>
+            </html:form>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+function validateSpecimenLookupFile() {
+    var input = document.getElementById('specimenFile');
+    var error = document.getElementById('specimenFilenameError');
+    var filename = input && input.value ? input.value.split(/[/\\]/).pop() : '';
+    var message = '';
+
+    if (!filename) {
+        message = 'Choose a specimen list file before submitting.';
+    } else if (filename.toLowerCase().slice(-4) !== '.txt') {
+        message = 'File must be a plain .txt file.';
+    } else if (filename.toLowerCase().indexOf('specimen') === -1) {
+        message = "Filename must contain 'specimen'.";
+    }
+
+    if (message) {
+        error.innerHTML = message;
+        error.style.display = 'block';
+        input.focus();
+        return false;
+    }
+    error.innerHTML = '';
+    error.style.display = 'none';
+    return true;
+}
+</script>

--- a/web/curate/specimen/specimenListLookup.jsp
+++ b/web/curate/specimen/specimenListLookup.jsp
@@ -1,0 +1,13 @@
+<%@ page language="java" %>
+<%@ page errorPage="/error.jsp" %>
+<%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="/WEB-INF/struts-tiles.tld" prefix="tiles" %>
+
+<%@include file="/curate/curatorCheck.jsp" %>
+<%@include file="/common/antweb_admin-defs.jsp" %>
+
+<tiles:insert beanName="antweb.default" beanScope="request" flush="true">
+    <tiles:put name="title" value="Specimen List Lookup" />
+    <tiles:put name="body-content" value="/curate/specimen/specimenListLookup-body.jsp" />
+</tiles:insert>

--- a/web/data/specimen_list_lookup_template.txt
+++ b/web/data/specimen_list_lookup_template.txt
@@ -1,0 +1,3 @@
+casent0104501
+casent0104502
+casent0179915


### PR DESCRIPTION
## Summary

- moves Specimen List Lookup under Read-Only Tools
- makes the tool visible and accessible to all curators
- adds a dedicated instructions and upload page
- adds filename, file-size, row-count, and specimen-code validation
- adds a downloadable template
- uses batched, read-only database lookups
- preserves the existing legacy upload handler

## Performance

A local end-to-end lookup of 100,000 specimen codes completed in 34.93 seconds and returned all 100,000 rows plus the TSV header. This is below Cloudflare's 100-second timeout, though production timing through Cloudflare should still be confirmed.

## Testing

- Ant compilation passed
- `SpecimenListLookupServiceTest`: 5 tests passed
- verified with a non-admin curator account
- verified unauthenticated access is rejected
- verified inline filename validation
- existing `AntWebStrutsTest` failures remain due to its hard-coded `/Users/mark/...` path

Related to #56 