### PR TITLE
Prevent duplicate genus rows that break subfamily pages

### DIFF
--- a/src/org/calacademy/antweb/home/AntwebDb.java
+++ b/src/org/calacademy/antweb/home/AntwebDb.java
@@ -94,7 +94,26 @@ public class AntwebDb {
         if ("leptanillinaeprotanilla".equals(taxonName)) s_log.debug("isExists() taxonName:" + taxonName + " retVal:" + retVal + " query:" + query);
         return retVal;
     }
-            
+    public boolean isGenusExists(String subfamily, String genus) {
+        boolean retVal = false;
+        String query = "select taxon_name from taxon where subfamily = '" + subfamily + "' and genus = '" + genus + "' and taxarank = 'genus'";
+        Statement stmt = null;
+        ResultSet rset = null;
+        try {
+          Connection connection = getConnection();
+          stmt = DBUtil.getStatement(connection, "AntwebDb.isGenusExists()");
+          stmt.execute(query);
+          rset = stmt.getResultSet();
+          while (rset.next()) {
+            retVal = true;
+          }
+        } catch (SQLException e) {
+          s_log.warn("isGenusExists() subfamily:" + subfamily + " genus:" + genus + " e:" + e);
+        } finally {
+          DBUtil.close(stmt, "AntwebDb.isGenusExists()");
+        }
+        return retVal;
+    }        
     public int delete(String taxonName) {
         String dml = "delete from taxon where taxon_name = '" + taxonName + "'";
         Statement stmt = null;

--- a/src/org/calacademy/antweb/home/UploadDb.java
+++ b/src/org/calacademy/antweb/home/UploadDb.java
@@ -579,8 +579,13 @@ Debug the above method UploadDb.passGenusSubfamilyCheck();
       Statement stmt = null; 
       try {
       
-        //new TaxonDb(getConnection()).delete(taxonName);
+                //new TaxonDb(getConnection()).delete(taxonName);
         if (new TaxonDb(getConnection()).isExists(taxonName)) return 0;
+
+        if (new TaxonDb(getConnection()).isGenusExists(subfamily, genus)) {
+            s_log.warn("insertGenus() genus row already exists for subfamily:" + subfamily + " genus:" + genus + ". Not inserting taxonName:" + taxonName);
+            return 0;
+        }
         
         dml = "insert into taxon (taxon_name, family, subfamily, genus, taxarank, source, insert_method, status, access_group) "
             + " values ('" + taxonName + "', '" + family + "', '" + subfamily + "', '" + genus + "', 'genus', '" 


### PR DESCRIPTION
## Problem

A specimen upload on 2025-10-28 created two `taxon` rows with `taxarank='genus'`,
`subfamily='myrmicinae'` and `genus='genus fhg01'`. `TaxonDb.getTaxonName()` looks
up a genus by subfamily + genus + taxarank, so with two matching rows it could not
return one, and the Myrmicinae subfamily page failed with:

    Did not get unique result. subfamily:myrmicinae genus:genus fhg01 rank:genus

Myrmicinae was unreachable for ten months — home page, taxon pages and image pages
alike.

## Cause

The uploaded genus value contained a space. Two code paths derived `taxon_name`
from it and disagreed:

| Path | insert_method | Result |
|---|---|---|
| specimen upload | `specimenUpload` | `myrmicinaegenus` (truncated at the space) |
| genus insert | `insertGenus` | `myrmicinaegenus fhg01` (full value) |

`UploadDb.insertGenus()` already guards against duplicates, but via
`AntwebDb.isExists(taxonName)` — keyed on `taxon_name`. Since the two paths produced
*different* `taxon_name` values, that guard could not fire. The invariant actually
relied on downstream — one genus row per subfamily + genus — was never checked.

## Change

- `AntwebDb.isGenusExists(subfamily, genus)` — checks for an existing row at
  `taxarank='genus'`, mirroring the style of the adjacent `isExists()`.
- `UploadDb.insertGenus()` — calls it before inserting, logs and returns 0 if a
  genus row already exists.

This makes the duplicate structurally impossible regardless of what upstream sends.

## Not included

Input validation rejecting whitespace in Subfamily/Genus/Species/subspecies fields.
Worth doing separately — it adds a new rejection path that every uploaded record
passes through, so it carries more risk than this guard does.

## Testing

Not compiled locally; relying on the Actions build. The production data was cleaned
by hand and the Myrmicinae page is loading again.