### PR TITLE
Reject upload records with whitespace in taxonomic fields

### DIFF
--- a/src/org/calacademy/antweb/upload/MessageMgr.java
+++ b/src/org/calacademy/antweb/upload/MessageMgr.java
@@ -160,6 +160,7 @@ public class MessageMgr {
     public static final String invalidSpeciesName = "invalidSpeciesName";
     public static final String specialCharacterFound = "specialCharacterFound";
     public static final String specimenIdSpacesRemoved = "specimenIdSpacesRemoved";
+    public static final String whitespaceInTaxonField = "whitespaceInTaxonField";
     // public static final String  = "";
     
      
@@ -233,8 +234,9 @@ public class MessageMgr {
       testList.add(new Test(invalidSpeciesName, SET, "<b>Invalid species name <font color=red>(not uploaded)</font></b>"));
 
       testList.add(new Test(specialCharacterFound, SET, "<b>Special Character Found <font color=red>(not uploaded)</font></b>"));
-      testList.add(new Test(specimenIdSpacesRemoved, SET, "<b>Spaces removed from specimen code (auto-corrected — please fix your source data)</b>"));
-    }      
+			testList.add(new Test(specimenIdSpacesRemoved, SET, "<b>Spaces removed from specimen code (auto-corrected — please fix your source data)</b>"));
+      testList.add(new Test(whitespaceInTaxonField, SET, "<b>Whitespace in taxonomic field <font color=red>(not uploaded)</font> — please fix your source data</b>"));
+    }     
     
     public static String getMessageDisplay(String key) {
       Test test = new MessageMgr().getTest(key);

--- a/src/org/calacademy/antweb/upload/SpecimenUploadParse.java
+++ b/src/org/calacademy/antweb/upload/SpecimenUploadParse.java
@@ -38,6 +38,12 @@ public abstract class SpecimenUploadParse extends SpecimenUploadProcess {
             "kingdom_name", "phylum_name", "class_name", "order_name", "specimencode", "family", "subfamily", "tribe",
             "genus", "subgenus", "speciesgroup", "species", "subspecies"));
 
+    // Fields that must never contain whitespace. Deliberately excludes specimencode
+    // (spaces auto-corrected, see MessageMgr.specimenIdSpacesRemoved) and taxon_name
+    // (legitimately contains a space between genus and species).
+    private final HashSet<String> noWhitespaceHeaders = new HashSet<>(Arrays.asList(
+            "subfamily", "genus", "species", "subspecies"));
+
     private final SpecimenXML specimenXML = new SpecimenXML();
 
     SpecimenUploadParse(Connection connection) {
@@ -111,8 +117,14 @@ public abstract class SpecimenUploadParse extends SpecimenUploadProcess {
                         col = col.toLowerCase();
  
                         /* This code block handles columns and headers as listed and defined in AntwebUpload */
-                        if (taxonomyHeaders.contains(col)) {
+                    if (taxonomyHeaders.contains(col)) {
                             element = element.toLowerCase();
+                        }
+
+                        if (noWhitespaceHeaders.contains(col) && element.contains(" ")) {
+                            errorMessage = "whitespace in taxonomic field col:" + col + " element:" + element;
+                            getMessageMgr().addToMessages(MessageMgr.whitespaceInTaxonField, col + ": " + element);
+                            return errorMessage;
                         }
 
                         if (col.equals("kingdom_name")) {


### PR DESCRIPTION
## Why

Follow-up to #58. A genus value containing a space (`Genus FHG01`) caused two
conflicting `taxon` rows and took the Myrmicinae subfamily page offline for ten
months. #58 added a guard in `UploadDb.insertGenus()` that makes the duplicate
structurally impossible. This rejects the bad input at parse time so it never
reaches the database.

## Rule

Reject any record where `subfamily`, `genus`, `species` or `subspecies` contains a
space. None of these fields can legitimately contain whitespace — each holds a
single word. `specimencode` is deliberately excluded (spaces auto-corrected, test
46) and so is `taxon_name`, which legitimately contains a space between genus and
species.

Line 97 already trims and collapses whitespace runs, and tabs are the field
delimiter, so the only whitespace reachable at this point is a single internal
space.

## Reject rather than strip

Stripping would have turned `Genus FHG01` into `genusfhg01`, and
`irritans inferior_cf` (species and subspecies crammed into one field) into
`irritansinferior_cf` — valid, unique, and taxa nobody chose, which then get pages,
enter the API and flow to GBIF. Rejection also pushes the fix back to the curator's
own source database; stripping silently fixes AntWeb and leaves the source wrong
forever, so the bad value returns on every subsequent upload.

## Impact

A scan of the whole `taxon` table found exactly one whitespace-bearing value across
all four fields, and it is junk (`(indet)dont exist (indet)`, specimen52.txt). No
warn-then-enforce rollout needed.

Rejection drops the whole specimen record, not just the name. A curator with one bad
genus across 300 specimens loses all 300 until they correct one field — the upload
report names the field and the value.

## Testing

Not exercised — `staging` has diverged from master by 15 commits and could not take
this branch cleanly. Relying on the Actions build for compilation. The rejection path
is gated on `noWhitespaceHeaders.contains(col)`, so records without whitespace in
those four fields are unaffected.